### PR TITLE
Add additional Jumpstart set data

### DIFF
--- a/library/Avatar/Aang.txt
+++ b/library/Avatar/Aang.txt
@@ -1,0 +1,16 @@
+Momo, Rambunctious Rascal
+Kindly Customer
+Invasion Reinforcements
+Water Tribe Captain
+Koala-Sheep
+Kyoshi Warriors
+Aang, Airbending Master
+Appa, Loyal Sky Bison
+Cloudshift
+Enter the Avatar State
+Path to Redemption
+Airbending Lesson
+Thriving Heath
+6 Plains [2t8d3N5Gn1ecBNsDqjQuJe]
+1 Plains Appa [6rlws0Y9bsjCxQpb7zzpYk]
+

--- a/library/Avatar/Adaptive.txt
+++ b/library/Avatar/Adaptive.txt
@@ -1,0 +1,16 @@
+Glider Kids
+Kyoshi Battle Fan
+Rowdy Snowballers
+Katara, Bending Prodigy
+Princess Yue
+The Blue Spirit
+Teo, Spirited Glider
+Giant Koi
+Boomerang Basics
+Frantic Search
+Lost in the Spirit World
+Waterbending Lesson
+Thriving Isle
+6 Island [QMIWFqwRUK1NLBxjbbXXL]
+Island Appa [5qtAqNeW80BB7BCgfUsB1S]
+

--- a/library/Avatar/Adept-(1).txt
+++ b/library/Avatar/Adept-(1).txt
@@ -1,0 +1,16 @@
+Professor Zei, Anthropologist
+Forecasting Fortune Teller
+Katara, Bending Prodigy
+Iguana Parrot
+Turtle-Seals
+Giant Koi
+Serpent of the Pass
+Unagi's Spray
+Dramatic Reversal
+Crashing Wave
+Nightmares and Daydreams
+Waterbending Lesson
+Thriving Isle
+6 Island [QMIWFqwRUK1NLBxjbbXXL]
+Island Appa [5qtAqNeW80BB7BCgfUsB1S]
+

--- a/library/Avatar/Adept-(2).txt
+++ b/library/Avatar/Adept-(2).txt
@@ -1,0 +1,16 @@
+Professor Zei, Anthropologist
+Master Pakku
+Katara, Bending Prodigy
+Iguana Parrot
+Teo, Spirited Glider
+Geyser Leaper
+Serpent of the Pass
+Octopus Form
+Consider
+Nightmares and Daydreams
+Waterbending Lesson
+Lost Days
+Thriving Isle
+6 Island [QMIWFqwRUK1NLBxjbbXXL]
+Island Appa [5qtAqNeW80BB7BCgfUsB1S]
+

--- a/library/Avatar/Airbending.txt
+++ b/library/Avatar/Airbending.txt
@@ -1,0 +1,16 @@
+Jeong Jeong's Deserters
+Invasion Reinforcements
+Glider Kids
+Koala-Sheep
+Monk Gyatso
+Aang, the Last Airbender
+Rabaroo Troop
+Appa, Loyal Sky Bison
+Airbender Ascension
+Path to Redemption
+Airbending Lesson
+Airbender's Reversal
+Thriving Heath
+6 Plains [2t8d3N5Gn1ecBNsDqjQuJe]
+1 Plains Appa [6rlws0Y9bsjCxQpb7zzpYk]
+

--- a/library/Avatar/Alliance-(1).txt
+++ b/library/Avatar/Alliance-(1).txt
@@ -1,0 +1,16 @@
+The Duke, Rebel Sentry
+South Pole Voyager
+Kyoshi Warrior Guard
+Glider Kids
+Sokka, Lateral Strategist
+Kyoshi Warriors
+Suki, Kyoshi Warrior
+Jet, Freedom Fighter
+Mechanical Glider
+Sokka's Sword Training
+Path to Redemption
+Fancy Footwork
+Thriving Heath
+6 Plains [2t8d3N5Gn1ecBNsDqjQuJe]
+1 Plains Appa [6rlws0Y9bsjCxQpb7zzpYk]
+

--- a/library/Avatar/Alliance-(2).txt
+++ b/library/Avatar/Alliance-(2).txt
@@ -1,0 +1,16 @@
+The Duke, Rebel Sentry
+South Pole Voyager
+Inspired Insurgent
+Glider Kids
+Sokka, Lateral Strategist
+Kyoshi Warriors
+Suki, Kyoshi Warrior
+Jet, Rebel Leader
+Mechanical Glider
+Acrobatic Leap
+Razor Rings
+Fancy Footwork
+Thriving Heath
+6 Plains [2t8d3N5Gn1ecBNsDqjQuJe]
+1 Plains Appa [6rlws0Y9bsjCxQpb7zzpYk]
+

--- a/library/Avatar/At-the Zoo.txt
+++ b/library/Avatar/At-the Zoo.txt
@@ -1,0 +1,16 @@
+Turtle-Duck
+Animal Attendant
+Frog-Squirrels
+Ostrich-Horse
+Elephant-Mandrill
+Eel-Hounds
+Diligent Zookeeper
+Saber-Tooth Moose-Lion
+Pillar Launch
+Origin of Metalbending
+Bison Whistle
+Hog-Monkey Rampage
+Thriving Grove
+6 Forest
+1 Forest Appa
+

--- a/library/Avatar/Azula.txt
+++ b/library/Avatar/Azula.txt
@@ -1,0 +1,16 @@
+Dai Li Censor
+Corrupt Court Official
+Fire Nation Ambushers
+Fire Navy Trebuchet
+Azula, Ruthless Firebender
+Lo and Li, Twin Tutors
+Canyon Crawler
+Sold Out
+Azula Always Lies
+Dai Li Indoctrination
+Epic Downfall
+Dark Deal
+Thriving Moor
+6 Swamp [2pg7yK46FjfULGbih0fdxt]
+Swamp Appa [5XyfjEMjAdCfmSyDWhQWLr]
+

--- a/library/Avatar/Bad-Advice.txt
+++ b/library/Avatar/Bad-Advice.txt
@@ -1,0 +1,16 @@
+Gilacorn
+Dai Li Censor
+Corrupt Court Official
+Joo Dee, One of Many
+Long Feng, Grand Secretariat
+Fire Nation Ambushers
+Lo and Li, Royal Advisors
+Hama, the Bloodbender
+Sold Out
+Dai Li Indoctrination
+Ozai's Cruelty
+Deadly Precision
+Thriving Moor
+6 Swamp [2pg7yK46FjfULGbih0fdxt]
+Swamp Appa [5XyfjEMjAdCfmSyDWhQWLr]
+

--- a/library/Avatar/Bounty-Hunter (1).txt
+++ b/library/Avatar/Bounty-Hunter (1).txt
@@ -1,0 +1,16 @@
+Purple Pentapus
+Pretending Poxbearers
+June, Bounty Hunter
+Pirate Peddlers
+Giant Fly
+Azula, On the Hunt
+Beetle-Headed Merchants
+Nyla, Shirshu Sleuth
+Sold Out
+Zuko's Conviction
+Bastion of Remembrance
+Deadly Precision
+Thriving Moor
+6 Swamp [2pg7yK46FjfULGbih0fdxt]
+Swamp Appa [5XyfjEMjAdCfmSyDWhQWLr]
+

--- a/library/Avatar/Bounty-Hunter (2).txt
+++ b/library/Avatar/Bounty-Hunter (2).txt
@@ -1,0 +1,16 @@
+Callous Inspector
+Pretending Poxbearers
+June, Bounty Hunter
+Pirate Peddlers
+Fire Navy Trebuchet
+Azula, On the Hunt
+Zhao, Ruthless Admiral
+Nyla, Shirshu Sleuth
+Sold Out
+Obsessive Pursuit
+Bastion of Remembrance
+Deadly Precision
+Thriving Moor
+6 Swamp [2pg7yK46FjfULGbih0fdxt]
+Swamp Appa [5XyfjEMjAdCfmSyDWhQWLr]
+

--- a/library/Avatar/Bumi.txt
+++ b/library/Avatar/Bumi.txt
@@ -1,0 +1,16 @@
+Raucous Audience
+Bumi's Feast Lecture
+Aang, A Lot to Learn
+Walltop Sentries
+Earthbending Lesson
+Badgermole
+Bumi, King of Three Trials
+Flopsie, Bumi's Buddy
+Origin of Metalbending
+Rocky Rebuke
+Creeping Crystal Coating
+Crystalline Armor
+Thriving Grove
+6 Forest
+1 Forest Appa
+

--- a/library/Avatar/Cabbages.txt
+++ b/library/Avatar/Cabbages.txt
@@ -1,0 +1,16 @@
+Unlucky Cabbage Merchant
+Bumi's Feast Lecture
+Elephant-Mandrill
+The Cabbage Merchant
+Foggy Swamp Vinebender
+Bosco, Just a Bear
+Hippo-Cows
+Saber-Tooth Moose-Lion
+Many Partings
+Leaves from the Vine
+The Art of Tea
+Rocky Rebuke
+Thriving Grove
+6 Forest
+1 Forest Appa
+

--- a/library/Avatar/Earth-Kingdom (1).txt
+++ b/library/Avatar/Earth-Kingdom (1).txt
@@ -1,0 +1,16 @@
+Haru, Hidden Talent
+Kyoshi Battle Fan
+Toph, the Blind Bandit
+Match the Odds
+Suki, Kyoshi Warrior
+Foggy Swamp Vinebender
+Earth Kingdom Soldier
+Hippo-Cows
+Mechanical Glider
+Stand United
+Descendants' Path
+Allies at Last
+Thriving Grove
+6 Forest
+1 Forest Appa
+

--- a/library/Avatar/Earth-Kingdom (2).txt
+++ b/library/Avatar/Earth-Kingdom (2).txt
@@ -1,0 +1,16 @@
+Haru, Hidden Talent
+Great Divide Guide
+Toph, the Blind Bandit
+Walltop Sentries
+Suki, Kyoshi Warrior
+Earth Kingdom General
+Earth Kingdom Soldier
+Hippo-Cows
+Mechanical Glider
+Origin of Metalbending
+Descendants' Path
+Allies at Last
+Thriving Grove
+6 Forest
+1 Forest Appa
+

--- a/library/Avatar/Earth-Rumble (1).txt
+++ b/library/Avatar/Earth-Rumble (1).txt
@@ -1,0 +1,16 @@
+Rebellious Captives
+Raucous Audience
+Kyoshi Battle Fan
+Uncle Iroh
+Toph, the Blind Bandit
+The Boulder, Ready to Rumble
+Earth Rumble Wrestlers
+Hippo-Cows
+Pillar Launch
+Hog-Monkey Rampage
+Master's Guidance
+Earth Rumble
+Thriving Grove
+6 Forest
+1 Forest Appa
+

--- a/library/Avatar/Earth-Rumble (2).txt
+++ b/library/Avatar/Earth-Rumble (2).txt
@@ -1,0 +1,16 @@
+Frog-Squirrels
+Raucous Audience
+Kyoshi Battle Fan
+Uncle Iroh
+The Earth King
+The Boulder, Ready to Rumble
+Earth Rumble Wrestlers
+Bosco, Just a Bear
+Origin of Metalbending
+Hog-Monkey Rampage
+Allies at Last
+Master's Guidance
+Thriving Grove
+6 Forest
+1 Forest Appa
+

--- a/library/Avatar/Earthbending-(1).txt
+++ b/library/Avatar/Earthbending-(1).txt
@@ -1,0 +1,16 @@
+Turtle-Duck
+Rebellious Captives
+Earth Kingdom Soldier
+Toph, the Blind Bandit
+Earthbending Lesson
+Earth Kingdom General
+Hippo-Cows
+Explore
+Rocky Rebuke
+Earthbender Ascension
+Inspiring Call
+Rumble Arena
+Thriving Grove
+6 Forest
+1 Forest Appa
+

--- a/library/Avatar/Earthbending-(2).txt
+++ b/library/Avatar/Earthbending-(2).txt
@@ -1,0 +1,16 @@
+Rebellious Captives
+Frog-Squirrels
+Earth Kingdom Soldier
+Toph, the Blind Bandit
+Earthbending Lesson
+Earth Kingdom General
+Badgermole
+Explore
+Rocky Rebuke
+Tale of Katara and Toph
+Solid Ground
+Rumble Arena
+Thriving Grove
+6 Forest
+1 Forest Appa
+

--- a/library/Avatar/Fire-Nation.txt
+++ b/library/Avatar/Fire-Nation.txt
@@ -1,0 +1,16 @@
+Firebending Student
+Mai, Jaded Edge
+Ty Lee, Artful Acrobat
+Zuko, Seeking Honor
+Longshot, Rebel Bowman
+Fire Nation Attacks
+Firebending Lesson
+Cunning Maneuver
+Fists of Flame
+Lightning Strike
+How to Start a Riot
+Storm of Memories
+Thriving Bluff
+6 Mountain
+Mountain Appa
+

--- a/library/Avatar/Firebending-(1).txt
+++ b/library/Avatar/Firebending-(1).txt
@@ -1,0 +1,16 @@
+Fire Nation Cadets
+Fire Sages
+Firebender Ascension
+Loyal Fire Sage
+Jeong Jeong, the Deserter
+Zuko, Exiled Prince
+Dragon Moose
+Firebending Lesson
+Roku's Mastery
+Cunning Maneuver
+Lightning Strike
+Reckless Blaze
+Thriving Bluff
+6 Mountain
+Mountain Appa
+

--- a/library/Avatar/Firebending-(2).txt
+++ b/library/Avatar/Firebending-(2).txt
@@ -1,0 +1,16 @@
+Fire Nation Cadets
+Moku, Meandering Drummer
+Yuyan Archers
+Loyal Fire Sage
+Jeong Jeong, the Deserter
+Zuko, Exiled Prince
+Rough Rhino Cavalry
+Fire Nation Attacks
+Firebending Lesson
+Cunning Maneuver
+Combustion Technique
+Reckless Blaze
+Thriving Bluff
+6 Mountain
+Mountain Appa
+

--- a/library/Avatar/Freedom-Fighters.txt
+++ b/library/Avatar/Freedom-Fighters.txt
@@ -1,0 +1,16 @@
+The Duke, Rebel Sentry
+Jeong Jeong's Deserters
+Inspired Insurgent
+Toucan-Puffin
+Pipsqueak, Rebel Strongarm
+Jet, Rebel Leader
+Wandering Musicians
+Rabaroo Troop
+Acrobatic Leap
+Path to Redemption
+Valorous Stance
+Hook Swords
+Thriving Heath
+6 Plains [2t8d3N5Gn1ecBNsDqjQuJe]
+1 Plains Appa [6rlws0Y9bsjCxQpb7zzpYk]
+

--- a/library/Avatar/Gliding-(1).txt
+++ b/library/Avatar/Gliding-(1).txt
@@ -1,0 +1,16 @@
+Momo, Friendly Flier
+Kindly Customer
+Toucan-Puffin
+Koala-Sheep
+Air Nomad Student
+Aang, the Last Airbender
+Rabaroo Troop
+Appa, Loyal Sky Bison
+Yip Yip!
+Path to Redemption
+Airbending Lesson
+Glider Staff
+Thriving Heath
+6 Plains [2t8d3N5Gn1ecBNsDqjQuJe]
+1 Plains Appa [6rlws0Y9bsjCxQpb7zzpYk]
+

--- a/library/Avatar/Gliding-(2).txt
+++ b/library/Avatar/Gliding-(2).txt
@@ -1,0 +1,16 @@
+Momo, Friendly Flier
+Jeong Jeong's Deserters
+Inspired Insurgent
+Glider Kids
+Water Tribe Captain
+Air Nomad Student
+Aang, the Last Airbender
+Appa, Loyal Sky Bison
+Yip Yip!
+Path to Redemption
+Tale of Momo
+Glider Staff
+Thriving Heath
+6 Plains [2t8d3N5Gn1ecBNsDqjQuJe]
+1 Plains Appa [6rlws0Y9bsjCxQpb7zzpYk]
+

--- a/library/Avatar/Hei-Bai (1).txt
+++ b/library/Avatar/Hei-Bai (1).txt
@@ -1,0 +1,16 @@
+Invasion Reinforcements
+Pretending Poxbearers
+Aang, A Lot to Learn
+Koala-Sheep
+Suki, Courageous Rescuer
+Vengeful Villagers
+Hei Bai, Spirit of Balance
+Rabaroo Troop
+Acrobatic Leap
+Path to Redemption
+That's Rough Buddy
+Sandbenders' Storm
+Thriving Heath
+6 Plains [2t8d3N5Gn1ecBNsDqjQuJe]
+1 Plains Appa [6rlws0Y9bsjCxQpb7zzpYk]
+

--- a/library/Avatar/Hei-Bai (2).txt
+++ b/library/Avatar/Hei-Bai (2).txt
@@ -1,0 +1,16 @@
+Curious Farm Animals
+Jeong Jeong's Deserters
+Pretending Poxbearers
+Aang, A Lot to Learn
+Suki, Courageous Rescuer
+Aardvark Sloth
+Hei Bai, Spirit of Balance
+Rabaroo Troop
+Sokka's Sword Training
+Path to Redemption
+That's Rough Buddy
+Destined Confrontation
+Thriving Heath
+6 Plains [2t8d3N5Gn1ecBNsDqjQuJe]
+1 Plains Appa [6rlws0Y9bsjCxQpb7zzpYk]
+

--- a/library/Avatar/Hunting-(1).txt
+++ b/library/Avatar/Hunting-(1).txt
@@ -1,0 +1,16 @@
+Purple Pentapus
+Elephant-Rat
+June, Bounty Hunter
+Raven Eagle
+Messenger Hawk
+Katara, Seeking Revenge
+Foggy Swamp Hunters
+Beetle-Headed Merchants
+Desperate Plea
+Epic Downfall
+Diresight
+Deadly Precision
+Thriving Moor
+6 Swamp [2pg7yK46FjfULGbih0fdxt]
+Swamp Appa [5XyfjEMjAdCfmSyDWhQWLr]
+

--- a/library/Avatar/Hunting-(2).txt
+++ b/library/Avatar/Hunting-(2).txt
@@ -1,0 +1,16 @@
+Gilacorn
+Ruthless Waterbender
+June, Bounty Hunter
+Raven Eagle
+Messenger Hawk
+Katara, Seeking Revenge
+Foggy Swamp Hunters
+Beetle-Headed Merchants
+Azula Always Lies
+Swampsnare Trap
+Diresight
+Deadly Precision
+Thriving Moor
+6 Swamp [2pg7yK46FjfULGbih0fdxt]
+Swamp Appa [5XyfjEMjAdCfmSyDWhQWLr]
+

--- a/library/Avatar/Insurgent-(1).txt
+++ b/library/Avatar/Insurgent-(1).txt
@@ -1,0 +1,16 @@
+Momo, Rambunctious Rascal
+Inspired Insurgent
+Jeong Jeong's Deserters
+Invasion Reinforcements
+Glider Kids
+Kyoshi Warriors
+Aang, the Last Airbender
+Appa, Loyal Sky Bison
+Razor Rings
+Stand United
+Airbender's Reversal
+Tale of Momo
+Thriving Heath
+6 Plains [2t8d3N5Gn1ecBNsDqjQuJe]
+1 Plains Appa [6rlws0Y9bsjCxQpb7zzpYk]
+

--- a/library/Avatar/Insurgent-(2).txt
+++ b/library/Avatar/Insurgent-(2).txt
@@ -1,0 +1,16 @@
+Momo, Rambunctious Rascal
+Inspired Insurgent
+Kyoshi Warrior Guard
+Sokka, Lateral Strategist
+Glider Kids
+Kyoshi Warriors
+Hakoda, Selfless Commander
+Appa, Loyal Sky Bison
+Path to Redemption
+Stand United
+That's Rough Buddy
+Duelist's Heritage
+Thriving Heath
+6 Plains [2t8d3N5Gn1ecBNsDqjQuJe]
+1 Plains Appa [6rlws0Y9bsjCxQpb7zzpYk]
+

--- a/library/Avatar/Iroh.txt
+++ b/library/Avatar/Iroh.txt
@@ -1,0 +1,16 @@
+Deserter's Disciple
+Tiger-Dillo
+Boar-q-pine
+Zuko, Seeking Honor
+Jeong Jeong, the Deserter
+Iroh, Dragon of the West
+Mongoose Lizard
+Firebending Lesson
+Iroh's Demonstration
+Cathartic Reunion
+Bolt Bend
+Fiery Confluence
+Thriving Bluff
+6 Mountain
+Mountain Appa
+

--- a/library/Avatar/Katara.txt
+++ b/library/Avatar/Katara.txt
@@ -1,0 +1,16 @@
+Gran-Gran
+Master Pakku
+Katara, Waterbending Master
+Rowdy Snowballers
+Sokka, Lateral Strategist
+Turtle-Seals
+Geyser Leaper
+Consider
+Watery Grasp
+Octopus Form
+It'll Quench Ya!
+Sokka's Haiku
+Thriving Isle
+6 Island [QMIWFqwRUK1NLBxjbbXXL]
+Island Appa [5qtAqNeW80BB7BCgfUsB1S]
+

--- a/library/Avatar/Kyoshi.txt
+++ b/library/Avatar/Kyoshi.txt
@@ -1,0 +1,16 @@
+Kyoshi Battle Fan
+Raucous Audience
+Elephant-Mandrill
+Kyoshi Warrior Exemplars
+Suki, Kyoshi Warrior
+Earth Kingdom Soldier
+Avatar Kyoshi, Earthbender
+Rocky Rebuke
+Cycle of Renewal
+Allies at Last
+Cracked Earth Technique
+Tectonic Split
+Thriving Grove
+6 Forest
+1 Forest Appa
+

--- a/library/Avatar/Learning-(1).txt
+++ b/library/Avatar/Learning-(1).txt
@@ -1,0 +1,16 @@
+Rebellious Captives
+Sparring Dummy
+Walltop Sentries
+Aang, A Lot to Learn
+Guru Pathik
+Saber-Tooth Moose-Lion
+Origin of Metalbending
+Shared Roots
+Rocky Rebuke
+Crystalline Armor
+Cracked Earth Technique
+Zuko's Exile
+Thriving Grove
+6 Forest
+1 Forest Appa
+

--- a/library/Avatar/Learning-(2).txt
+++ b/library/Avatar/Learning-(2).txt
@@ -1,0 +1,16 @@
+Platypus-Bear
+Sparring Dummy
+Walltop Sentries
+Aang, A Lot to Learn
+Uncle Iroh
+Saber-Tooth Moose-Lion
+The Art of Tea
+True Ancestry
+Rocky Rebuke
+Master's Guidance
+Cracked Earth Technique
+Zuko's Exile
+Thriving Grove
+6 Forest
+1 Forest Appa
+

--- a/library/Avatar/Lessons-(1).txt
+++ b/library/Avatar/Lessons-(1).txt
@@ -1,0 +1,16 @@
+Gran-Gran
+Glider Kids
+Platypus-Bear
+Iguana Parrot
+Katara, Seeking Revenge
+Giant Koi
+Octopus Form
+Boomerang Basics
+Accumulate Wisdom
+It'll Quench Ya!
+Chakra Meditation
+Whirlwind Technique
+Thriving Isle
+6 Island [QMIWFqwRUK1NLBxjbbXXL]
+Island Appa [5qtAqNeW80BB7BCgfUsB1S]
+

--- a/library/Avatar/Lessons-(2).txt
+++ b/library/Avatar/Lessons-(2).txt
@@ -1,0 +1,16 @@
+Gran-Gran
+Master Pakku
+Platypus-Bear
+Iguana Parrot
+Katara, Seeking Revenge
+Geyser Leaper
+Octopus Form
+Accumulate Wisdom
+Chakra Meditation
+Waterbending Lesson
+Lost Days
+Whirlwind Technique
+Thriving Isle
+6 Island [QMIWFqwRUK1NLBxjbbXXL]
+Island Appa [5qtAqNeW80BB7BCgfUsB1S]
+

--- a/library/Avatar/Librarian.txt
+++ b/library/Avatar/Librarian.txt
@@ -1,0 +1,16 @@
+Professor Zei, Anthropologist
+Suspicious Bookcase
+Knowledge Seeker
+Dutiful Knowledge Seeker
+Wan Shi Tong, All-Knowing
+Giant Koi
+Brainstorm
+Octopus Form
+Accumulate Wisdom
+Lost in the Spirit World
+Waterbending Lesson
+Zuko's Exile
+Thriving Isle
+6 Island [QMIWFqwRUK1NLBxjbbXXL]
+Island Appa [5qtAqNeW80BB7BCgfUsB1S]
+

--- a/library/Avatar/Musicians.txt
+++ b/library/Avatar/Musicians.txt
@@ -1,0 +1,17 @@
+Freedom Fighter Recruit
+Moku, Meandering Drummer
+Ty Lee, Artful Acrobat
+Founding of Omashu
+Wandering Musicians
+Chong and Lily, Nomads
+Rough Rhino Cavalry
+Mongoose Lizard
+Explosive Shot
+Cunning Maneuver
+Bumi Bash
+The Cave of Two Lovers
+Thriving Bluff
+Secret Tunnel
+5 Mountain
+Mountain Appa
+

--- a/library/Avatar/Nightmares.txt
+++ b/library/Avatar/Nightmares.txt
@@ -1,0 +1,16 @@
+Purple Pentapus
+Pretending Poxbearers
+Joo Dee, One of Many
+Pirate Peddlers
+Azula, On the Hunt
+Hei Bai, Spirit of Balance
+Canyon Crawler
+Koh, the Face Stealer
+Zuko's Conviction
+Desperate Plea
+Ruinous Waterbending
+Deadly Precision
+Thriving Moor
+6 Swamp [2pg7yK46FjfULGbih0fdxt]
+Swamp Appa [5XyfjEMjAdCfmSyDWhQWLr]
+

--- a/library/Avatar/Ozai.txt
+++ b/library/Avatar/Ozai.txt
@@ -1,0 +1,16 @@
+Callous Inspector
+Corrupt Court Official
+Fire Nation Ambushers
+Fire Navy Trebuchet
+Fire Lord Ozai
+Zhao, Ruthless Admiral
+Beetle-Headed Merchants
+Canyon Crawler
+Heartless Act
+Ozai's Cruelty
+Scarring Memories
+Deadly Precision
+Thriving Moor
+6 Swamp [2pg7yK46FjfULGbih0fdxt]
+Swamp Appa [5XyfjEMjAdCfmSyDWhQWLr]
+

--- a/library/Avatar/Powerful-(1).txt
+++ b/library/Avatar/Powerful-(1).txt
@@ -1,0 +1,16 @@
+Deserter's Disciple
+Tiger-Dillo
+Uncle Iroh
+Earth Rumble Wrestlers
+Fire Nation Raider
+Fang, Roku's Companion
+Rough Rhino Cavalry
+Mongoose Lizard
+Firebending Lesson
+Iroh's Demonstration
+Cathartic Reunion
+Twin Blades
+Thriving Bluff
+6 Mountain
+Mountain Appa
+

--- a/library/Avatar/Powerful-(2).txt
+++ b/library/Avatar/Powerful-(2).txt
@@ -1,0 +1,16 @@
+Freedom Fighter Recruit
+Tiger-Dillo
+Uncle Iroh
+Komodo Rhino
+Fire Nation Raider
+Fang, Roku's Companion
+Combustion Man
+Mongoose Lizard
+Firebending Lesson
+Hog-Monkey Rampage
+Cathartic Reunion
+How to Start a Riot
+Thriving Bluff
+6 Mountain
+Mountain Appa
+

--- a/library/Avatar/Rebelling-(1).txt
+++ b/library/Avatar/Rebelling-(1).txt
@@ -1,0 +1,16 @@
+Freedom Fighter Recruit
+Yuyan Archers
+Treetop Freedom Fighters
+Zuko, Seeking Honor
+Longshot, Rebel Bowman
+Smellerbee, Rebel Fighter
+Jet, Freedom Fighter
+Fire Nation Attacks
+Explosive Shot
+Cunning Maneuver
+How to Start a Riot
+Bumi Bash
+Thriving Bluff
+6 Mountain
+Mountain Appa
+

--- a/library/Avatar/Rebelling-(2).txt
+++ b/library/Avatar/Rebelling-(2).txt
@@ -1,0 +1,16 @@
+Freedom Fighter Recruit
+Deserter's Disciple
+Treetop Freedom Fighters
+Zuko, Seeking Honor
+Hook Swords
+Longshot, Rebel Bowman
+Smellerbee, Rebel Fighter
+Jet, Freedom Fighter
+Explosive Shot
+Run Amok
+How to Start a Riot
+Overwhelming Victory
+Thriving Bluff
+6 Mountain
+Mountain Appa
+

--- a/library/Avatar/Reinforced-(1).txt
+++ b/library/Avatar/Reinforced-(1).txt
@@ -1,0 +1,16 @@
+Callous Inspector
+Elephant-Rat
+Long Feng, Grand Secretariat
+Hog-Monkey
+Zuko, Seeking Honor
+Buzzard-Wasp Colony
+Fire Nation Salvagers
+Beetle-Headed Merchants
+Azula Always Lies
+Dai Li Indoctrination
+Epic Downfall
+Feed the Swarm
+Thriving Moor
+6 Swamp [2pg7yK46FjfULGbih0fdxt]
+Swamp Appa [5XyfjEMjAdCfmSyDWhQWLr]
+

--- a/library/Avatar/Reinforced-(2).txt
+++ b/library/Avatar/Reinforced-(2).txt
@@ -1,0 +1,16 @@
+Gilacorn
+Elephant-Rat
+Hog-Monkey
+Long Feng, Grand Secretariat
+Earth Village Ruffians
+Zuko, Seeking Honor
+Buzzard-Wasp Colony
+Fire Nation Salvagers
+Fatal Fissure
+Dai Li Indoctrination
+Heartless Act
+Deadly Precision
+Thriving Moor
+6 Swamp [2pg7yK46FjfULGbih0fdxt]
+Swamp Appa [5XyfjEMjAdCfmSyDWhQWLr]
+

--- a/library/Avatar/Relentless-(1).txt
+++ b/library/Avatar/Relentless-(1).txt
@@ -1,0 +1,16 @@
+Purple Pentapus
+Merchant of Many Hats
+Ruthless Waterbender
+Pirate Peddlers
+Fire Nation Ambushers
+Azula, On the Hunt
+Buzzard-Wasp Colony
+Canyon Crawler
+Sold Out
+Azula Always Lies
+Heartless Act
+Fire Nation Occupation
+Thriving Moor
+6 Swamp [2pg7yK46FjfULGbih0fdxt]
+Swamp Appa [5XyfjEMjAdCfmSyDWhQWLr]
+

--- a/library/Avatar/Relentless-(2).txt
+++ b/library/Avatar/Relentless-(2).txt
@@ -1,0 +1,16 @@
+Callous Inspector
+Merchant of Many Hats
+Joo Dee, One of Many
+Fire Nation Ambushers
+Azula, On the Hunt
+Zhao, Ruthless Admiral
+Beetle-Headed Merchants
+Canyon Crawler
+Azula Always Lies
+Heartless Act
+Fire Nation Occupation
+Deadly Precision
+Thriving Moor
+6 Swamp [2pg7yK46FjfULGbih0fdxt]
+Swamp Appa [5XyfjEMjAdCfmSyDWhQWLr]
+

--- a/library/Avatar/Roku.txt
+++ b/library/Avatar/Roku.txt
@@ -1,0 +1,16 @@
+Yuyan Archers
+Fire Sages
+Boar-q-pine
+Loyal Fire Sage
+Jeong Jeong, the Deserter
+Fang, Roku's Companion
+Avatar Roku, Firebender
+Firebending Lesson
+Frantic Confrontation
+Roku's Mastery
+Crescent Island Temple
+White Lotus Hideout
+Thriving Bluff
+6 Mountain
+Mountain Appa
+

--- a/library/Avatar/Shrines.txt
+++ b/library/Avatar/Shrines.txt
@@ -1,0 +1,21 @@
+Raucous Audience
+Walltop Sentries
+Hei Bai, Forest Guardian
+Guru Pathik
+Saber-Tooth Moose-Lion
+Barrels of Blasting Jelly
+Northern Air Temple
+Aang's Journey
+The Spirit Oasis
+Kyoshi Island Plaza
+Southern Air Temple
+Crescent Island Temple
+Thriving Grove
+White Lotus Hideout
+Plains
+Island
+Swamp
+Mountain
+Forest
+Forest Appa
+

--- a/library/Avatar/Siege-Engines.txt
+++ b/library/Avatar/Siege-Engines.txt
@@ -1,0 +1,16 @@
+Callous Inspector
+Merchant of Many Hats
+Pretending Poxbearers
+Fire Nation Engineer
+Fire Navy Trebuchet
+Fire Nation Warship
+Tundra Tank
+The Fire Nation Drill
+Beetle-Headed Merchants
+Canyon Crawler
+Heartless Act
+Deadly Precision
+Thriving Moor
+6 Swamp [2pg7yK46FjfULGbih0fdxt]
+Swamp Appa [5XyfjEMjAdCfmSyDWhQWLr]
+

--- a/library/Avatar/Soaring-(1).txt
+++ b/library/Avatar/Soaring-(1).txt
@@ -1,0 +1,16 @@
+Flying Dolphin-Fish
+Forecasting Fortune Teller
+Messenger Hawk
+Sokka, Lateral Strategist
+The Mechanist, Aerial Artisan
+Teo, Spirited Glider
+Cat-Owl
+Giant Koi
+Watery Grasp
+Mechanical Glider
+Boomerang Basics
+Sokka's Haiku
+Thriving Isle
+6 Island [QMIWFqwRUK1NLBxjbbXXL]
+Island Appa [5qtAqNeW80BB7BCgfUsB1S]
+

--- a/library/Avatar/Soaring-(2).txt
+++ b/library/Avatar/Soaring-(2).txt
@@ -1,0 +1,16 @@
+Flying Dolphin-Fish
+Benevolent River Spirit
+Messenger Hawk
+Sokka, Lateral Strategist
+Teo, Spirited Glider
+Cat-Owl
+Yue, the Moon Spirit
+Giant Koi
+Watery Grasp
+Octopus Form
+Boomerang Basics
+Frantic Search
+Thriving Isle
+6 Island [QMIWFqwRUK1NLBxjbbXXL]
+Island Appa [5qtAqNeW80BB7BCgfUsB1S]
+

--- a/library/Avatar/Sparky-Sparky (1).txt
+++ b/library/Avatar/Sparky-Sparky (1).txt
@@ -1,0 +1,16 @@
+Fire Nation Cadets
+Fire Sages
+Deer-Dog
+War Balloon
+Zuko, Exiled Prince
+Earth Rumble Wrestlers
+Combustion Man
+Ran and Shaw
+Iroh's Demonstration
+Combustion Technique
+How to Start a Riot
+Bumi Bash
+Thriving Bluff
+6 Mountain
+Mountain Appa
+

--- a/library/Avatar/Sparky-Sparky (2).txt
+++ b/library/Avatar/Sparky-Sparky (2).txt
@@ -1,0 +1,16 @@
+Fire Nation Cadets
+Yuyan Archers
+Deer-Dog
+War Balloon
+Zuko, Exiled Prince
+Dragon Moose
+Combustion Man
+Ran and Shaw
+Firebending Lesson
+Combustion Technique
+Price of Freedom
+Overwhelming Victory
+Thriving Bluff
+6 Mountain
+Mountain Appa
+

--- a/library/Avatar/Spirit.txt
+++ b/library/Avatar/Spirit.txt
@@ -1,0 +1,16 @@
+Flying Dolphin-Fish
+Benevolent River Spirit
+Knowledge Seeker
+Dutiful Knowledge Seeker
+Baboon Spirit
+Flexible Waterbender
+Giant Koi
+Octopus Form
+Dramatic Reversal
+It'll Quench Ya!
+Lost in the Spirit World
+The Spirit Oasis
+Thriving Isle
+6 Island [QMIWFqwRUK1NLBxjbbXXL]
+Island Appa [5qtAqNeW80BB7BCgfUsB1S]
+

--- a/library/Avatar/Swordmaster.txt
+++ b/library/Avatar/Swordmaster.txt
@@ -1,0 +1,16 @@
+Earth Kingdom Protectors
+Kyoshi Battle Fan
+Inspired Insurgent
+Sokka, Swordmaster
+Glider Kids
+Aardvark Sloth
+Master Piandao
+Trusty Boomerang
+Sokka's Sword Training
+Razor Rings
+Duelist's Heritage
+Meteor Sword
+Thriving Heath
+6 Plains [2t8d3N5Gn1ecBNsDqjQuJe]
+1 Plains Appa [6rlws0Y9bsjCxQpb7zzpYk]
+

--- a/library/Avatar/Toph.txt
+++ b/library/Avatar/Toph.txt
@@ -1,0 +1,16 @@
+Rebellious Captives
+Frog-Squirrels
+Toph, Earthbending Master
+Earth Kingdom Soldier
+Kyoshi Warrior Exemplars
+Earth Kingdom General
+Badgermole
+Saber-Tooth Moose-Lion
+Rocky Rebuke
+Origin of Metalbending
+Tale of Katara and Toph
+Solid Ground
+Thriving Grove
+6 Forest
+1 Forest Appa
+

--- a/library/Avatar/Underwater.txt
+++ b/library/Avatar/Underwater.txt
@@ -1,0 +1,16 @@
+Flying Dolphin-Fish
+Invasion Submersible
+Rowdy Snowballers
+Turtle-Seals
+Tui and La, Moon and Ocean
+Giant Koi
+Serpent of the Pass
+Unagi's Spray
+Octopus Form
+Honest Work
+Coastal Piracy
+White Lotus Hideout
+Thriving Isle
+6 Island [QMIWFqwRUK1NLBxjbbXXL]
+Island Appa [5qtAqNeW80BB7BCgfUsB1S]
+

--- a/library/Avatar/Warriors.txt
+++ b/library/Avatar/Warriors.txt
@@ -1,0 +1,16 @@
+Kyoshi Warrior Guard
+Invasion Reinforcements
+Kyoshi Battle Fan
+Toucan-Puffin
+Sokka, Lateral Strategist
+Suki, Kyoshi Captain
+Kyoshi Warriors
+Rabaroo Troop
+Path to Redemption
+Sokka's Sword Training
+Valorous Stance
+Team Avatar
+Thriving Heath
+6 Plains [2t8d3N5Gn1ecBNsDqjQuJe]
+1 Plains Appa [6rlws0Y9bsjCxQpb7zzpYk]
+

--- a/library/Avatar/Wise-(1).txt
+++ b/library/Avatar/Wise-(1).txt
@@ -1,0 +1,16 @@
+Gran-Gran
+Forecasting Fortune Teller
+Otter-Penguin
+Katara, Bending Prodigy
+Rowdy Snowballers
+Messenger Hawk
+Turtle-Seals
+Consider
+Waterbender's Restoration
+Waterbending Lesson
+Coastal Piracy
+Whirlwind Technique
+Thriving Isle
+6 Island [QMIWFqwRUK1NLBxjbbXXL]
+Island Appa [5qtAqNeW80BB7BCgfUsB1S]
+

--- a/library/Avatar/Wise-(2).txt
+++ b/library/Avatar/Wise-(2).txt
@@ -1,0 +1,16 @@
+Tiger-Seal
+Otter-Penguin
+Knowledge Seeker
+Sokka, Lateral Strategist
+Rowdy Snowballers
+Messenger Hawk
+Turtle-Seals
+The Blue Spirit
+Consider
+It'll Quench Ya!
+Sokka's Haiku
+Whirlwind Technique
+Thriving Isle
+6 Island [QMIWFqwRUK1NLBxjbbXXL]
+Island Appa [5qtAqNeW80BB7BCgfUsB1S]
+

--- a/library/Avatar/Zuko.txt
+++ b/library/Avatar/Zuko.txt
@@ -1,0 +1,16 @@
+Yuyan Archers
+Zuko, Firebending Master
+Mai, Jaded Edge
+War Balloon
+Dragon Moose
+Fire Nation Attacks
+Mongoose Lizard
+Frantic Confrontation
+Firebending Lesson
+Fists of Flame
+Lightning Strike
+Lost in Memories
+Thriving Bluff
+6 Mountain
+Mountain Appa
+

--- a/library/Dominaria United Jumpstart/Arcane-Mischief.txt
+++ b/library/Dominaria United Jumpstart/Arcane-Mischief.txt
@@ -1,0 +1,15 @@
+Cosmic Epiphany
+Random blue rare or mythic rare
+Haunting Figment
+Soaring Drake
+Academy Wall
+Talas Lookout
+Frostfist Strider
+Djinn of the Fountain
+Impulse
+Shore Up
+Combat Research
+Impede Momentum
+5 Island
+1 Island [Full Art Stained Glass]
+2 Island [Foil]

--- a/library/Dominaria United Jumpstart/Beast-Territory.txt
+++ b/library/Dominaria United Jumpstart/Beast-Territory.txt
@@ -1,0 +1,19 @@
+1 Briar Hydra
+1 Random green rare or mythic rare
+1 Floriferous Vinewall
+1 Sunbathing Rootwalla
+1 Deathbloom Gardener
+1 Magnigoth Sentry
+1 Territorial Maro
+1 Linebreaker Baloth
+1 Mossbeard Ancient
+1 Bite Down
+1 Broken Wings
+1 Slimefoot's Survey
+1 Wooded Ridgeline
+1 Radiant Grove
+1 Haunted Mire
+1 Tangled Islet
+1 Forest
+1 Forest [Full Art Stained Glass]
+2 Forest [Foil]

--- a/library/Dominaria United Jumpstart/Coalition-Corps.txt
+++ b/library/Dominaria United Jumpstart/Coalition-Corps.txt
@@ -1,0 +1,15 @@
+1 Serra Redeemer
+1 Random white rare or mythic rare, or Karn, Living Legacy
+1 Clockwork Drawbridge
+1 Resolute Reinforcements
+1 Argivian Cavalier
+1 Charismatic Vanguard
+1 Captain's Call
+1 Griffin Protector
+1 Argivian Phalanx
+1 Prayer of Binding
+1 Join Forces
+1 Love Song of Night and Day
+5 Plains
+1 Plains [Full Art Stained Glass]
+2 Plains [Foil]

--- a/library/Dominaria United Jumpstart/Coalition-Legion.txt
+++ b/library/Dominaria United Jumpstart/Coalition-Legion.txt
@@ -1,0 +1,15 @@
+1 Serra Redeemer
+1 Random white rare or mythic rare, or Karn, Living Legacy
+1 Samite Herbalist
+1 Benalish Faithbonder
+1 Knight of Dawn's Light
+1 Argivian Cavalier
+1 Charismatic Vanguard
+1 Griffin Protector
+1 Take Up the Shield
+1 Prayer of Binding
+1 Join Forces
+1 Love Song of Night and Day
+5 Plains
+1 Plains [Full Art Stained Glass]
+2 Plains [Foil]

--- a/library/Dominaria United Jumpstart/Monster-Territory.txt
+++ b/library/Dominaria United Jumpstart/Monster-Territory.txt
@@ -1,0 +1,19 @@
+1 Briar Hydra
+1 Random green rare or mythic rare
+1 Floriferous Vinewall
+1 Sunbathing Rootwalla
+1 Nishoba Brawler
+1 The Weatherseed Treaty
+1 Magnigoth Sentry
+1 Territorial Maro
+1 Yavimaya Sojourner
+1 Gaea's Might
+1 Slimefoot's Survey
+1 Bite Down
+1 Wooded Ridgeline
+1 Radiant Grove
+1 Haunted Mire
+1 Tangled Islet
+1 Forest
+1 Forest [Full Art Stained Glass]
+2 Forest [Foil]

--- a/library/Dominaria United Jumpstart/Mystic-Mischief.txt
+++ b/library/Dominaria United Jumpstart/Mystic-Mischief.txt
@@ -1,0 +1,15 @@
+1 Cosmic Epiphany
+1 Random blue rare or mythic rare
+1 Coral Colony
+1 Soaring Drake
+1 Academy Wall
+1 Talas Lookout
+1 Tolarian Terror
+1 Frostfist Strider
+1 Impulse
+1 Impede Momentum
+1 Ertai's Scorn
+1 Founding the Third Path
+5 Island
+1 Island [Full Art Stained Glass]
+2 Island [Foil]

--- a/library/Dominaria United Jumpstart/Ready-To-Attack.txt
+++ b/library/Dominaria United Jumpstart/Ready-To-Attack.txt
@@ -1,0 +1,15 @@
+1 Ragefire Hellkite
+1 Random red rare or mythic rare
+1 Phoenix Chick
+1 Electrostatic Infantry
+1 Goblin Picker
+1 Flowstone Kavu
+1 Dragon Whelp
+1 Coalition Warbrute
+1 Hammerhand
+1 Lightning Strike
+1 Jaya's Firenado
+1 Twinferno
+5 Mountain
+1 Mountain [Full Art Stained Glass]
+2 Mountain [Foil]

--- a/library/Dominaria United Jumpstart/Ready-To-Charge.txt
+++ b/library/Dominaria United Jumpstart/Ready-To-Charge.txt
@@ -1,0 +1,15 @@
+1 Ragefire Hellkite
+1 Random red rare or mythic rare
+1 Electrostatic Infantry
+1 Yavimaya Steelcrusher
+1 Balduvian Berserker
+1 Dragon Whelp
+1 Coalition Warbrute
+1 Molten Monstrosity
+1 Flowstone Infusion
+1 Twinferno
+1 Jaya's Firenado
+1 Furious Bellow
+5 Mountain
+1 Mountain [Full Art Stained Glass]
+2 Mountain [Foil]

--- a/library/Dominaria United Jumpstart/Totally-Merciless.txt
+++ b/library/Dominaria United Jumpstart/Totally-Merciless.txt
@@ -1,0 +1,15 @@
+1 Tyrannical Pitlord
+1 Random black rare or mythic rare, or Weatherlight Compleated
+1 Knight of Dusk's Shadow
+1 Phyrexian Vivisector
+1 Eerie Soultender
+1 Phyrexian Rager
+1 Sengir Connoisseur
+1 Writhing Necromass
+1 Battle-Rage Blessing
+1 Pilfer
+1 Braids's Frightful Return
+1 Extinguish the Light
+5 Swamp
+1 Swamp [Full Art Stained Glass]
+2 Swamp [Foil]

--- a/library/Dominaria United Jumpstart/Totally-Ruthless.txt
+++ b/library/Dominaria United Jumpstart/Totally-Ruthless.txt
@@ -1,0 +1,15 @@
+1 Tyrannical Pitlord
+1 Random black rare or mythic rare, or Weatherlight Compleated
+1 Cult Conscript
+1 Phyrexian Vivisector
+1 Splatter Goblin
+1 Phyrexian Rager
+1 Gibbering Barricade
+1 Sengir Connoisseur
+1 Bone Splinters
+1 Cut Down
+1 Battle-Rage Blessing
+1 Braids's Frightful Return
+5 Swamp
+1 Swamp [Full Art Stained Glass]
+2 Swamp [Foil]

--- a/library/Foundations/Angels-(1).txt
+++ b/library/Foundations/Angels-(1).txt
@@ -1,0 +1,15 @@
+Giada, Font of Hope
+Faithful Pikemaster
+Starnheim Memento
+Celestial Enforcer
+Destroy Evil
+Herald of the Sun
+Inspiring Overseer
+Light of Hope
+Pacifism
+Serra Angel
+Youthful Valkyrie
+Secluded Steppe
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Angels-(2).txt
+++ b/library/Foundations/Angels-(2).txt
@@ -1,0 +1,15 @@
+Giada, Font of Hope
+Herald of War
+Faithful Pikemaster
+Starnheim Memento
+Angelic Edict
+Herald of the Sun
+Inspiring Overseer
+Pacifism
+Rally of Wings
+Stalwart Valkyrie
+Youthful Valkyrie
+Secluded Steppe
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Armed-(1).txt
+++ b/library/Foundations/Armed-(1).txt
@@ -1,0 +1,15 @@
+Mace of the Valiant
+Faithful Pikemaster
+Starnheim Memento
+Danitha Capashen, Paragon
+Ancestral Blade
+Divine Arrow
+Fencing Ace
+Mirran Bardiche
+Pacifism
+Starnheim Courser
+Sunspear Shikari
+Valkyrie's Sword
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Armed-(2).txt
+++ b/library/Foundations/Armed-(2).txt
@@ -1,0 +1,15 @@
+Stone Haven Outfitter
+Faithful Pikemaster
+Danitha Capashen, Paragon
+Plate Armor
+Ancestral Blade
+Divine Arrow
+Fencing Ace
+Hexgold Hoverwings
+Light the Way
+Militant Inquisitor
+Mirran Bardiche
+Pacifism
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Armed-(3).txt
+++ b/library/Foundations/Armed-(3).txt
@@ -1,0 +1,15 @@
+Maul of the Skyclaves
+Faithful Pikemaster
+Danitha Capashen, Paragon
+Ancestral Blade
+Fencing Ace
+Flutterfox
+Militant Inquisitor
+Mirran Bardiche
+Pacifism
+Resistance Reunited
+Trusty Retriever
+Valkyrie's Sword
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Armed-(4).txt
+++ b/library/Foundations/Armed-(4).txt
@@ -1,0 +1,15 @@
+Godsend
+Faithful Pikemaster
+Danitha Capashen, Paragon
+Plate Armor
+Ancestral Blade
+Deadly Riposte
+Fencing Ace
+Militant Inquisitor
+Mirran Bardiche
+Pacifism
+Sunspear Shikari
+Thopter Architect
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Beasts-(1).txt
+++ b/library/Foundations/Beasts-(1).txt
@@ -1,0 +1,15 @@
+Slinza, the Spiked Stampede
+Hungry Megasloth
+Spined Tyrranax
+Woodland Liege
+Explore
+Gift of the Gargantuan
+Advocate of the Beast
+Brushstrider
+Gnarlid Colony
+Obstinate Baloth
+Predator's Strike
+Time to Feed
+Thriving Grove
+6 Forest
+

--- a/library/Foundations/Beasts-(2).txt
+++ b/library/Foundations/Beasts-(2).txt
@@ -1,0 +1,15 @@
+Slinza, the Spiked Stampede
+Garruk, Caller of Beasts
+Hungry Megasloth
+Woodland Liege
+Advocate of the Beast
+Baloth Gorger
+Brushstrider
+Bushwhack
+Garruk's Packleader
+Gnarlid Colony
+Predator's Strike
+Time to Feed
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Bloody-(1).txt
+++ b/library/Foundations/Bloody-(1).txt
@@ -1,0 +1,15 @@
+Anje's Ravager
+Ivora, Insatiable Heir
+Abandon Reason
+Belligerent Guest
+Blood Petal Celebrant
+Falkenrath Celebrants
+Flame-Blessed Bolt
+Incorrigible Youths
+Soul Sear
+Stolen Vitality
+Voldaren Duelist
+Voldaren Epicure
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Bloody-(2).txt
+++ b/library/Foundations/Bloody-(2).txt
@@ -1,0 +1,15 @@
+Markov Blademaster
+Markov Enforcer
+Ivora, Insatiable Heir
+Blood Hypnotist
+Blood Petal Celebrant
+Falkenrath Celebrants
+Flame-Blessed Bolt
+Insolent Neonate
+Markov Retribution
+Soul Sear
+Stolen Vitality
+Voldaren Duelist
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Bloody-(3).txt
+++ b/library/Foundations/Bloody-(3).txt
@@ -1,0 +1,15 @@
+Scion of Opulence
+Ivora, Insatiable Heir
+Blood Feud
+Belligerent Guest
+Blood Petal Celebrant
+Falkenrath Celebrants
+Flame-Blessed Bolt
+Insolent Neonate
+Markov Warlord
+Soul Sear
+Vampiric Fury
+Voldaren Duelist
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Bloody-(4).txt
+++ b/library/Foundations/Bloody-(4).txt
@@ -1,0 +1,15 @@
+Falkenrath Marauders
+Ivora, Insatiable Heir
+Blood Feud
+Belligerent Guest
+Blood Petal Celebrant
+Falkenrath Celebrants
+Neonate's Rush
+Soul Sear
+Stolen Vitality
+Voldaren Ambusher
+Voldaren Duelist
+Voldaren Epicure
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Bookworms-(1).txt
+++ b/library/Foundations/Bookworms-(1).txt
@@ -1,0 +1,15 @@
+Overflowing Insight
+Starlight Snare
+Syr Elenora, the Discerning
+Blink of an Eye
+Cartouche of Knowledge
+Faerie Vandal
+Lat-Nam Adept
+Mystic Skyfish
+Reckless Scholar
+Shore Keeper
+Sky-Eel School
+Trial of Knowledge
+Thriving Isle
+7 Island
+

--- a/library/Foundations/Bookworms-(2).txt
+++ b/library/Foundations/Bookworms-(2).txt
@@ -1,0 +1,16 @@
+Teferi's Ageless Insight
+Phantasmal Shieldback
+Starlight Snare
+Syr Elenora, the Discerning
+Drag Under
+Uncomfortable Chill
+Faerie Vandal
+Muse Drake
+Mystic Skyfish
+Reckless Scholar
+Sky-Eel School
+Witching Well
+Memorial to Genius
+Thriving Isle
+6 Island
+

--- a/library/Foundations/Bookworms-(3).txt
+++ b/library/Foundations/Bookworms-(3).txt
@@ -1,0 +1,15 @@
+Sphinx of Enlightenment
+Starlight Snare
+Syr Elenora, the Discerning
+Drag Under
+Cartouche of Knowledge
+Lat-Nam Adept
+Mystic Skyfish
+Omen of the Sea
+Reckless Scholar
+Shore Keeper
+Thopter Mechanic
+Trial of Knowledge
+Thriving Isle
+7 Island
+

--- a/library/Foundations/Bookworms-(4).txt
+++ b/library/Foundations/Bookworms-(4).txt
@@ -1,0 +1,16 @@
+Nadir Kraken
+Phantasmal Shieldback
+Starlight Snare
+Syr Elenora, the Discerning
+Drag Under
+Faerie Vandal
+Lat-Nam Adept
+Opt
+Reckless Scholar
+Sky-Eel School
+Soul Read
+Tolarian Kraken
+Memorial to Genius
+Thriving Isle
+6 Island
+

--- a/library/Foundations/Burning.txt
+++ b/library/Foundations/Burning.txt
@@ -1,0 +1,15 @@
+Rionya, Fire Dancer
+Firespitter Whelp
+Hearts on Fire
+Fathom Fleet Firebrand
+Goblin Fireslinger
+Bloodfire Expert
+Chandra's Spitfire
+Firebrand Archer
+Flames of the Firebrand
+Jaya's Firenado
+Play with Fire
+Wildfire Elemental
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Chaos.txt
+++ b/library/Foundations/Chaos.txt
@@ -1,0 +1,19 @@
+Averna, the Chaos Bloom
+Shardless Outlander
+Chromatic Lantern
+Ash Barrens
+Terramorphic Expanse
+Fiery Fall
+Druid of the Anima
+Bituminous Blast
+Bloodbraid Elf
+Enlisted Wurm
+Fusion Elemental
+Violent Outburst
+Maelstrom Colossus
+Plains
+Island
+Swamp
+2 Mountain
+2 Forest
+

--- a/library/Foundations/Clerics-(1).txt
+++ b/library/Foundations/Clerics-(1).txt
@@ -1,0 +1,15 @@
+Taborax, Hope's Demise
+Nullpriest of Oblivion
+Revoke Demise
+Bonecaller Cleric
+Dark Bargain
+Agonizing Syphon
+Archfiend's Vessel
+Disfigure
+Eerie Soultender
+Koma's Faithful
+Scion of the Swarm
+Skemfar Shadowsage
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Clerics-(2).txt
+++ b/library/Foundations/Clerics-(2).txt
@@ -1,0 +1,15 @@
+Taborax, Hope's Demise
+Revoke Demise
+Bonecaller Cleric
+Dark Bargain
+Priest of Gix
+Archfiend's Vessel
+Disfigure
+Elderfang Disciple
+Entomber Exarch
+Koma's Faithful
+Scion of the Swarm
+Severed Strands
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Clerics-(3).txt
+++ b/library/Foundations/Clerics-(3).txt
@@ -1,0 +1,15 @@
+Vito, Thorn of the Dusk Rose
+Revoke Demise
+Bonecaller Cleric
+Dark Bargain
+Agonizing Syphon
+Dark Supplicant
+Eerie Soultender
+Elderfang Disciple
+Koma's Faithful
+Moment of Craving
+Scion of Darkness
+Skemfar Shadowsage
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Clerics-(4).txt
+++ b/library/Foundations/Clerics-(4).txt
@@ -1,0 +1,15 @@
+Vito, Thorn of the Dusk Rose
+Priest of Forgotten Gods
+Revoke Demise
+Bonecaller Cleric
+Dark Bargain
+Priest of Gix
+Alchemist's Gift
+Archfiend's Vessel
+Extinguish the Light
+Scion of the Swarm
+Skemfar Shadowsage
+Stronghold Confessor
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Copied-(1).txt
+++ b/library/Foundations/Copied-(1).txt
@@ -1,0 +1,15 @@
+Zada, Hedron Grinder
+Scholar of Combustion
+Guttersnipe
+Kiln Fiend
+Crimson Wisps
+Cyclops Electromancer
+Fire Prophecy
+Fists of Flame
+Invigorated Rampage
+Renegade Tactics
+Spellgorger Weird
+Young Pyromancer
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Copied-(2).txt
+++ b/library/Foundations/Copied-(2).txt
@@ -1,0 +1,15 @@
+Zada, Hedron Grinder
+Charmbreaker Devils
+Firespitter Whelp
+Hearts on Fire
+Scholar of Combustion
+Kiln Fiend
+Ancestral Anger
+Ancestral Anger
+Cyclops Electromancer
+Fire Prophecy
+Uncaged Fury
+Young Pyromancer
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Dinner.txt
+++ b/library/Foundations/Dinner.txt
@@ -1,0 +1,15 @@
+Hurska Sweet-Tooth
+Saurian Symbiote
+Bite Down
+Fierce Witchstalker
+Giant Opportunity
+Insatiable Appetite
+Maraleaf Rider
+Orchard Strider
+Tireless Provisioner
+Tough Cookie
+Trail of Crumbs
+Gingerbrute
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Dinosaurs-(1).txt
+++ b/library/Foundations/Dinosaurs-(1).txt
@@ -1,0 +1,15 @@
+Ghalta, Primal Hunger
+Saurian Symbiote
+Armored Kincaller
+Colossal Dreadmaw
+Commune with Dinosaurs
+Drover of the Mighty
+Drowsing Tyrannodon
+Giant Growth
+Rampant Growth
+Savage Stomp
+Thrashing Brontodon
+Thundering Spineback
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Dinosaurs-(2).txt
+++ b/library/Foundations/Dinosaurs-(2).txt
@@ -1,0 +1,15 @@
+Ghalta, Primal Hunger
+Topiary Stomper
+Saurian Symbiote
+Cherished Hatchling
+Colossal Dreadmaw
+Commune with Dinosaurs
+Drowsing Tyrannodon
+Predator's Strike
+Rampant Growth
+Tail Swipe
+Thrashing Brontodon
+Thundering Spineback
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Dragons-(1).txt
+++ b/library/Foundations/Dragons-(1).txt
@@ -1,0 +1,15 @@
+Lathliss, Dragon Queen
+Firespitter Whelp
+Carnelian Orb of Dragonkind
+Dragon's Fire
+Seize the Spoils
+Bathe in Dragonfire
+Dragon Hatchling
+Dragon Whelp
+Dragonlord's Servant
+Rapacious Dragon
+Sparktongue Dragon
+Forgotten Cave
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Dragons-(2).txt
+++ b/library/Foundations/Dragons-(2).txt
@@ -1,0 +1,15 @@
+Lathliss, Dragon Queen
+Sarkhan, Fireblood
+Firespitter Whelp
+Dragon's Fire
+Seize the Spoils
+Dragon Hatchling
+Dragon Whelp
+Dragonlord's Servant
+Hellkite Whelp
+Sarkhan's Rage
+Sparktongue Dragon
+Forgotten Cave
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Drowned-(1).txt
+++ b/library/Foundations/Drowned-(1).txt
@@ -1,0 +1,16 @@
+Neerdiv, Devious Diver
+Sudden Insight
+Deep Analysis
+Expendable Lackey
+Locked in the Cemetery
+Merfolk Pupil
+Organ Hoarder
+Screaming Swarm
+Shipwreck Dowser
+Silent Departure
+Stitched Drake
+Wall of Lost Thoughts
+Ipnu Rivulet
+Thriving Isle
+6 Island
+

--- a/library/Foundations/Drowned-(2).txt
+++ b/library/Foundations/Drowned-(2).txt
@@ -1,0 +1,15 @@
+Neerdiv, Devious Diver
+Cackling Counterpart
+Sudden Insight
+Cruel Witness
+Deep Analysis
+Draugr Thought-Thief
+Expendable Lackey
+Locked in the Cemetery
+Screaming Swarm
+Towering-Wave Mystic
+Waker of Waves
+Wall of Lost Thoughts
+Thriving Isle
+7 Island
+

--- a/library/Foundations/Elves-(1).txt
+++ b/library/Foundations/Elves-(1).txt
@@ -1,0 +1,15 @@
+Leaf-Crowned Visionary
+Razorgrass Invoker
+Dionus, Elvish Archdruid
+Elvish Visionary
+Llanowar Elves
+Arbor Armament
+Band Together
+Bounty of Skemfar
+Ghirapur Guide
+Overcome
+Tajuru Pathwarden
+Thornweald Archer
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Elves-(2).txt
+++ b/library/Foundations/Elves-(2).txt
@@ -1,0 +1,15 @@
+Elvish Archdruid
+Razorgrass Invoker
+Dionus, Elvish Archdruid
+Elvish Visionary
+Llanowar Elves
+Bounty of Skemfar
+Dwynen's Elite
+High-Rise Sawjack
+Hunter's Edge
+Kujar Seedsculptor
+Might of the Masses
+Overcome
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Elves-(3).txt
+++ b/library/Foundations/Elves-(3).txt
@@ -1,0 +1,15 @@
+Marwyn, the Nurturer
+Go Forth
+Razorgrass Invoker
+Dionus, Elvish Archdruid
+Llanowar Elves
+Band Together
+Bounty of Skemfar
+Dwynen's Elite
+Llanowar Visionary
+Overcome
+Tajuru Pathwarden
+Thornweald Archer
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Elves-(4).txt
+++ b/library/Foundations/Elves-(4).txt
@@ -1,0 +1,15 @@
+Tyvar Kell
+Voice of the Woods
+Dionus, Elvish Archdruid
+Llanowar Elves
+Arbor Armament
+Ghirapur Guide
+High-Rise Sawjack
+Hunter's Edge
+Ivy Lane Denizen
+Overcome
+Paradise Druid
+Reckless Amplimancer
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Enchanted-(1).txt
+++ b/library/Foundations/Enchanted-(1).txt
@@ -1,0 +1,15 @@
+Eidolon of Astral Winds
+Psemilla, Meletian Poet
+Banishing Light
+Archon of Falling Stars
+Captivating Unicorn
+Chosen by Heliod
+Dreadful Apathy
+Favored of Iroas
+Flutterfox
+Glory Bearers
+Indomitable Will
+Spirited Companion
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Enchanted-(2).txt
+++ b/library/Foundations/Enchanted-(2).txt
@@ -1,0 +1,15 @@
+Eidolon of Astral Winds
+Psemilla, Meletian Poet
+Banishing Light
+Archon of Falling Stars
+Cage of Hands
+Cartouche of Solidarity
+Flutterfox
+Glory Bearers
+Golden-Tail Disciple
+Indomitable Will
+Nyx-Fleece Ram
+Sunblade Samurai
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Enchanted-(3).txt
+++ b/library/Foundations/Enchanted-(3).txt
@@ -1,0 +1,15 @@
+Nykthos Paragon
+Starfield Mystic
+Psemilla, Meletian Poet
+Banishing Light
+Divine Favor
+Flutterfox
+Glory Bearers
+Golden-Tail Disciple
+Indomitable Will
+Nyx-Fleece Ram
+Serra's Embrace
+Sunblade Samurai
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Enchanted-(4).txt
+++ b/library/Foundations/Enchanted-(4).txt
@@ -1,0 +1,15 @@
+Archon of Sun's Grace
+Psemilla, Meletian Poet
+Banishing Light
+Angelic Gift
+Archon of Falling Stars
+Dreadful Apathy
+Favored of Iroas
+Flutterfox
+Golden-Tail Disciple
+Indomitable Will
+Spirited Companion
+Sunblade Samurai
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Encounter-(1).txt
+++ b/library/Foundations/Encounter-(1).txt
@@ -1,0 +1,15 @@
+Forgotten Ancient
+Spined Tyrranax
+Mowu, Loyal Companion
+Biogenic Upgrade
+Aggressive Instinct
+Ainok Artillerist
+Deepwood Denizen
+Duskshell Crawler
+Greenwood Sentinel
+Jiang Yanggu, Wildcrafter
+Servant of the Scale
+Snakeskin Veil
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Encounter-(2).txt
+++ b/library/Foundations/Encounter-(2).txt
@@ -1,0 +1,15 @@
+Oran-Rief Ooze
+Saurian Symbiote
+Spined Tyrranax
+Mowu, Loyal Companion
+Aggressive Instinct
+Deepwood Denizen
+Duskshell Crawler
+Greenwood Sentinel
+Invigorating Surge
+Jiang Yanggu, Wildcrafter
+Jungle Delver
+Stony Strength
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Encounter-(3).txt
+++ b/library/Foundations/Encounter-(3).txt
@@ -1,0 +1,15 @@
+Rishkar, Peema Renegade
+Saurian Symbiote
+Spined Tyrranax
+Mowu, Loyal Companion
+Biogenic Upgrade
+Aggressive Instinct
+Deepwood Denizen
+Duskshell Crawler
+Jiang Yanggu, Wildcrafter
+Reckless Amplimancer
+Servant of the Scale
+Snakeskin Veil
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Encounter-(4).txt
+++ b/library/Foundations/Encounter-(4).txt
@@ -1,0 +1,15 @@
+Primeval Bounty
+Quirion Beastcaller
+Hungry Megasloth
+Mowu, Loyal Companion
+Aggressive Instinct
+Armorcraft Judge
+Big Play
+Deepwood Denizen
+Gnarlid Colony
+Jiang Yanggu, Wildcrafter
+Moldgraf Millipede
+Pridemalkin
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Explorers-(1).txt
+++ b/library/Foundations/Explorers-(1).txt
@@ -1,0 +1,15 @@
+Realm Seekers
+Go Forth
+Razorgrass Invoker
+Slimy Piper
+Shardless Outlander
+Braulios of Pheres Band
+Explore
+Adventurous Impulse
+Ainok Guide
+Clear Shot
+Ghirapur Guide
+Tireless Provisioner
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Explorers-(2).txt
+++ b/library/Foundations/Explorers-(2).txt
@@ -1,0 +1,15 @@
+Tireless Tracker
+Go Forth
+Razorgrass Invoker
+Slimy Piper
+Shardless Outlander
+Braulios of Pheres Band
+Explore
+Ainok Guide
+Byway Courier
+Clear Shot
+Primeval Herald
+Ulvenwald Mysteries
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Explorers-(3).txt
+++ b/library/Foundations/Explorers-(3).txt
@@ -1,0 +1,15 @@
+Briarbridge Tracker
+Somberwald Beastmaster
+Go Forth
+Slimy Piper
+Shardless Outlander
+Braulios of Pheres Band
+Explore
+Ambassador Oak
+Byway Courier
+Clear Shot
+Ulvenwald Mysteries
+Woodland Champion
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Explorers-(4).txt
+++ b/library/Foundations/Explorers-(4).txt
@@ -1,0 +1,15 @@
+Jadelight Ranger
+Go Forth
+Razorgrass Invoker
+Slimy Piper
+Shardless Outlander
+Braulios of Pheres Band
+Explore
+Adventurous Impulse
+Clear Shot
+Ixalli's Diviner
+Merfolk Branchwalker
+Primeval Herald
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Fun-Guys (1).txt
+++ b/library/Foundations/Fun-Guys (1).txt
@@ -1,0 +1,15 @@
+Shroofus Sproutsire
+Saurian Symbiote
+Slimy Piper
+Band Together
+Fungal Plots
+Might of the Masses
+Overwhelm
+Saproling Migration
+Spore Crawler
+Spore Swarm
+Sporecrown Thallid
+Tukatongue Thallid
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Fun-Guys (2).txt
+++ b/library/Foundations/Fun-Guys (2).txt
@@ -1,0 +1,15 @@
+Shroofus Sproutsire
+Verdeloth the Ancient
+Saurian Symbiote
+Slimy Piper
+Undercellar Myconid
+Band Together
+For the Family
+Fungal Plots
+Overcome
+Saproling Migration
+Spore Swarm
+Sporecrown Thallid
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Ghastly-(1).txt
+++ b/library/Foundations/Ghastly-(1).txt
@@ -1,0 +1,15 @@
+Harvester of Souls
+Ozox, the Clattering King
+Blood Beckoning
+Doomed Dissenter
+Dross Hopper
+Falkenrath Noble
+Moan of the Unhallowed
+Morbid Opportunist
+Murder
+Tragic Slip
+Village Rites
+Wakedancer
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Ghastly-(2).txt
+++ b/library/Foundations/Ghastly-(2).txt
@@ -1,0 +1,15 @@
+Bloodgift Demon
+Ozox, the Clattering King
+Blood Beckoning
+Defenestrate
+Doomed Dissenter
+Falkenrath Noble
+Gnawing Zombie
+Moan of the Unhallowed
+Morbid Opportunist
+Tragic Slip
+Typhoid Rats
+Village Rites
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Ghastly-(3).txt
+++ b/library/Foundations/Ghastly-(3).txt
@@ -1,0 +1,15 @@
+Reaper from the Abyss
+Wriggling Grub
+Ozox, the Clattering King
+Deadly Dispute
+Blood Beckoning
+Boneclad Necromancer
+Dross Hopper
+Falkenrath Noble
+Morbid Opportunist
+Morkrut Behemoth
+Murder
+Tragic Slip
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Ghastly-(4).txt
+++ b/library/Foundations/Ghastly-(4).txt
@@ -1,0 +1,15 @@
+Army of the Damned
+Ozox, the Clattering King
+Deadly Dispute
+Shambling Ghast
+Crawl from the Cellar
+Defenestrate
+Doomed Dissenter
+Falkenrath Noble
+Moan of the Unhallowed
+Morbid Opportunist
+Tragic Slip
+Wakedancer
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Giddyap.txt
+++ b/library/Foundations/Giddyap.txt
@@ -1,0 +1,15 @@
+Thurid, Mare of Destiny
+Banishing Light
+Celestial Unicorn
+Steadfast Unicorn
+Tenacity
+Brightmare
+Moment of Triumph
+Outflank
+Ronom Unicorn
+Shield Mare
+Sungrace Pegasus
+Sunmane Pegasus
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Goblins-(1).txt
+++ b/library/Foundations/Goblins-(1).txt
@@ -1,0 +1,15 @@
+Dropkick Bomber
+Goblin Surprise
+General Kreat, the Boltbringer
+Battle Cry Goblin
+Krenko's Command
+Volley Veteran
+Brute Strength
+Fissure Wizard
+Goblin Researcher
+Open Fire
+Shock
+Weaselback Redcap
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Goblins-(2).txt
+++ b/library/Foundations/Goblins-(2).txt
@@ -1,0 +1,15 @@
+Dropkick Bomber
+Goblin Goliath
+Goblin Surprise
+General Kreat, the Boltbringer
+Battle Cry Goblin
+Krenko's Command
+Volley Veteran
+Goblin Arsonist
+Kindled Fury
+Mogg Flunkies
+Open Fire
+Shock
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Goblins-(3).txt
+++ b/library/Foundations/Goblins-(3).txt
@@ -1,0 +1,15 @@
+Krenko, Tin Street Kingpin
+Goblin Surprise
+General Kreat, the Boltbringer
+Beetleback Chief
+Goblin Smuggler
+Krenko's Command
+Volley Veteran
+Goblin Trailblazer
+Open Fire
+Scavenged Blade
+Shock
+Weaselback Redcap
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Goblins-(4).txt
+++ b/library/Foundations/Goblins-(4).txt
@@ -1,0 +1,15 @@
+Goblin Rabblemaster
+Goblin Surprise
+General Kreat, the Boltbringer
+Battle Cry Goblin
+Destructive Digger
+Krenko's Command
+Volley Veteran
+Brute Strength
+Fanatical Firebrand
+Fire Prophecy
+Fissure Wizard
+Shock
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Grave-Robbers (1).txt
+++ b/library/Foundations/Grave-Robbers (1).txt
@@ -1,0 +1,15 @@
+Gorex, the Tombshell
+Revoke Demise
+Eternal Taskmaster
+Deal Gone Bad
+Diregraf Scavenger
+Eye Collector
+Gorging Vulture
+Grave Strength
+Graveblade Marauder
+Gravedigger
+Murder
+Wailing Ghoul
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Grave-Robbers (2).txt
+++ b/library/Foundations/Grave-Robbers (2).txt
@@ -1,0 +1,15 @@
+Gorex, the Tombshell
+Doomed Necromancer
+Revoke Demise
+Eternal Taskmaster
+Deal Gone Bad
+Dusk Mangler
+Eye Collector
+Fake Your Own Death
+Gorging Vulture
+Moodmark Painter
+Necrotic Wound
+Undead Butler
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Grave-Robbers (3).txt
+++ b/library/Foundations/Grave-Robbers (3).txt
@@ -1,0 +1,16 @@
+Isareth the Awakener
+Revoke Demise
+Eternal Taskmaster
+Boneclad Necromancer
+Deal Gone Bad
+Dreadhound
+Gorging Vulture
+Grave Strength
+Gravedigger
+Murder
+Persistent Specimen
+Wailing Ghoul
+Memorial to Folly
+Thriving Moor
+6 Swamp
+

--- a/library/Foundations/Grave-Robbers (4).txt
+++ b/library/Foundations/Grave-Robbers (4).txt
@@ -1,0 +1,15 @@
+Isareth the Awakener
+Liliana, Death's Majesty
+Revoke Demise
+Shardless Outlander
+Eternal Taskmaster
+Deal Gone Bad
+Goremand
+Gorging Vulture
+Gravedigger
+Murder
+Persistent Specimen
+Undead Butler
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Healers-(1).txt
+++ b/library/Foundations/Healers-(1).txt
@@ -1,0 +1,16 @@
+Speaker of the Heavens
+Hinterland Sanctifier
+Qala, Ajani's Pridemate
+Ajani's Pridemate
+Angel of Mercy
+Angel of Vitality
+Brightmare
+Desperate Lunge
+Divine Arrow
+Faith's Fetters
+Mesa Unicorn
+Revitalize
+Kabira Crossroads
+Thriving Heath
+6 Plains
+

--- a/library/Foundations/Healers-(2).txt
+++ b/library/Foundations/Healers-(2).txt
@@ -1,0 +1,15 @@
+Valkyrie Harbinger
+Hinterland Sanctifier
+Qala, Ajani's Pridemate
+Ajani's Pridemate
+Angel of Vitality
+Bishop's Soldier
+Brightmare
+Divine Arrow
+Recumbent Bliss
+Revitalize
+Speakeasy Server
+Take Up the Shield
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Healers-(3).txt
+++ b/library/Foundations/Healers-(3).txt
@@ -1,0 +1,16 @@
+Righteous Valkyrie
+Hinterland Sanctifier
+Qala, Ajani's Pridemate
+Ajani's Pridemate
+Angel of Mercy
+Angel of Vitality
+Banisher Priest
+Daybreak Chaplain
+Deadly Riposte
+Moment of Heroism
+Recumbent Bliss
+Revitalize
+Kabira Crossroads
+Thriving Heath
+6 Plains
+

--- a/library/Foundations/Healers-(4).txt
+++ b/library/Foundations/Healers-(4).txt
@@ -1,0 +1,15 @@
+Felidar Sovereign
+Rhox Faithmender
+Hinterland Sanctifier
+Qala, Ajani's Pridemate
+Ajani's Pridemate
+Angel of Vitality
+Battlefield Promotion
+Brightmare
+Divine Arrow
+Faith's Fetters
+Mesa Unicorn
+Revitalize
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Heroes-(1).txt
+++ b/library/Foundations/Heroes-(1).txt
@@ -1,0 +1,15 @@
+Brigone, Soldier of Meletis
+Faithful Pikemaster
+Dauntless Onslaught
+Akroan Skyguard
+Chains of Custody
+Defiant Strike
+Favored Hoplite
+Fencing Ace
+Moment of Heroism
+Tethmos High Priest
+Valorous Stance
+Wingsteed Rider
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Heroes-(2).txt
+++ b/library/Foundations/Heroes-(2).txt
@@ -1,0 +1,15 @@
+Brigone, Soldier of Meletis
+Ojutai Exemplars
+Faithful Pikemaster
+Chains of Custody
+Defiant Strike
+Elite Skirmisher
+Favored Hoplite
+Fencing Ace
+Gird for Battle
+Repel the Darkness
+Valorous Stance
+Wingsteed Rider
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Icky-(1).txt
+++ b/library/Foundations/Icky-(1).txt
@@ -1,0 +1,15 @@
+Fumulus, the Infestation
+Wriggling Grub
+Eaten Alive
+Devouring Swarm
+Durable Coilbug
+Fretwork Colony
+Go for the Throat
+Heartstabber Mosquito
+Nantuko Husk
+Subtle Strike
+Swarm of Bloodflies
+Village Rites
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Icky-(2).txt
+++ b/library/Foundations/Icky-(2).txt
@@ -1,0 +1,15 @@
+Fumulus, the Infestation
+Endless Cockroaches
+Wriggling Grub
+Eaten Alive
+Devouring Swarm
+Go for the Throat
+Heartstabber Mosquito
+Morkrut Necropod
+Nantuko Husk
+Subtle Strike
+Torment of Scarabs
+Virus Beetle
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Illusions.txt
+++ b/library/Foundations/Illusions.txt
@@ -1,0 +1,15 @@
+Pol Jamaar, Illusionist
+Lord of the Unreal
+Phantasmal Shieldback
+Starlight Snare
+Murmuring Mystic
+Haunting Figment
+Krovikan Mist
+Oneirophage
+Opt
+Phantasmal Form
+Phantom Ninja
+Supreme Will
+Thriving Isle
+7 Island
+

--- a/library/Foundations/Inventive-(1).txt
+++ b/library/Foundations/Inventive-(1).txt
@@ -1,0 +1,16 @@
+Sai, Master Thopterist
+Gilded Scuttler
+Ornithopter of Paradise
+Blink of an Eye
+Bury in Books
+Experimental Aviator
+Filigree Attendant
+Gearseeker Serpent
+Chief of the Foundry
+Eager Construct
+Prophetic Prism
+Whirlermaker
+Seat of the Synod
+Thriving Isle
+6 Island
+

--- a/library/Foundations/Inventive-(2).txt
+++ b/library/Foundations/Inventive-(2).txt
@@ -1,0 +1,16 @@
+Sai, Master Thopterist
+Shimmer Dragon
+Gilded Scuttler
+Ornithopter of Paradise
+Experimental Aviator
+Malfunction
+Chief of the Foundry
+Eager Construct
+Fireshrieker
+Prophetic Prism
+Treasure Keeper
+Universal Solvent
+Seat of the Synod
+Thriving Isle
+6 Island
+

--- a/library/Foundations/Inventive-(3).txt
+++ b/library/Foundations/Inventive-(3).txt
@@ -1,0 +1,16 @@
+Padeem, Consul of Innovation
+Thought Monitor
+Gilded Scuttler
+Ornithopter of Paradise
+Experimental Aviator
+Fading Hope
+Malfunction
+Thoughtcast
+Chief of the Foundry
+Myr Enforcer
+Patchwork Automaton
+Prophetic Prism
+Seat of the Synod
+Thriving Isle
+6 Island
+

--- a/library/Foundations/Inventive-(4).txt
+++ b/library/Foundations/Inventive-(4).txt
@@ -1,0 +1,16 @@
+Padeem, Consul of Innovation
+Gilded Scuttler
+Shardless Outlander
+Ornithopter of Paradise
+Blink of an Eye
+Bury in Books
+Experimental Aviator
+Chief of the Foundry
+Eager Construct
+Guardian Idol
+Prophetic Prism
+Treasure Keeper
+Seat of the Synod
+Thriving Isle
+6 Island
+

--- a/library/Foundations/Landfall-(1).txt
+++ b/library/Foundations/Landfall-(1).txt
@@ -1,0 +1,15 @@
+Lotus Cobra
+Undergrowth Champion
+Sutina, Speaker of the Tajuru
+Adventure Awaits
+Baloth Woodcrasher
+Bite Down
+Canopy Baloth
+Harrow
+Kazandu Stomper
+Skyclave Pick-Axe
+Snapping Gnarlid
+Evolving Wilds
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Landfall-(2).txt
+++ b/library/Foundations/Landfall-(2).txt
@@ -1,0 +1,15 @@
+Ancient Greenwarden
+Sutina, Speaker of the Tajuru
+Bite Down
+Bond of Flourishing
+Canopy Baloth
+Kazandu Nectarpot
+Kazandu Stomper
+Krosan Tusker
+Retreat to Kazandu
+Snapping Gnarlid
+Territorial Scythecat
+Evolving Wilds
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Landfall-(3).txt
+++ b/library/Foundations/Landfall-(3).txt
@@ -1,0 +1,15 @@
+Scythecat Cub
+Sutina, Speaker of the Tajuru
+Bite Down
+Canopy Baloth
+Harrow
+Kazandu Stomper
+Murasa Ranger
+Retreat to Kazandu
+Snapping Gnarlid
+Territorial Scythecat
+Cliffhaven Kitesail
+Evolving Wilds
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Landfall-(4).txt
+++ b/library/Foundations/Landfall-(4).txt
@@ -1,0 +1,15 @@
+Scythecat Cub
+Sutina, Speaker of the Tajuru
+Baloth Woodcrasher
+Bite Down
+Canopy Baloth
+Grazing Gladehart
+Groundswell
+Harrow
+Skyclave Pick-Axe
+Snapping Gnarlid
+Sporemound
+Evolving Wilds
+Thriving Grove
+7 Forest
+

--- a/library/Foundations/Legion-(1).txt
+++ b/library/Foundations/Legion-(1).txt
@@ -1,0 +1,15 @@
+Adeline, Resplendent Cathar
+Dawnwing Marshal
+Hinterland Sanctifier
+Mentor of the Meek
+Raise the Alarm
+Ancestral Blade
+Argivian Phalanx
+Dauntless Unity
+Make a Stand
+Pacifism
+Recruitment Officer
+Search Party Captain
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Legion-(2).txt
+++ b/library/Foundations/Legion-(2).txt
@@ -1,0 +1,16 @@
+Adeline, Resplendent Cathar
+Venerated Loxodon
+Dawnwing Marshal
+Hinterland Sanctifier
+Mentor of the Meek
+Raise the Alarm
+Ancestral Blade
+Conclave Tribunal
+Dauntless Unity
+Defend the Campus
+Recruitment Officer
+Triplicate Spirits
+Memorial to Glory
+Thriving Heath
+6 Plains
+

--- a/library/Foundations/Modified.txt
+++ b/library/Foundations/Modified.txt
@@ -1,0 +1,16 @@
+Kodama of the West Tree
+Saurian Symbiote
+Shardless Outlander
+Audacity
+Defend the Celestus
+Gnarlid Colony
+Heir of the Ancient Fang
+Orochi Merge-Keeper
+Reckless Amplimancer
+Snakeskin Veil
+Warbriar Blessing
+Wolfrider's Saddle
+Cave of Temptation
+Thriving Grove
+6 Forest
+

--- a/library/Foundations/N'er-do-wells-(1).txt
+++ b/library/Foundations/N'er-do-wells-(1).txt
@@ -1,0 +1,15 @@
+Rev, Tithe Extractor
+Serpent Assassin
+Thieves' Tools
+Audacious Thief
+Crooked Custodian
+Fake Your Own Death
+Foul Play
+Masked Blackguard
+Midnight Assassin
+Morbid Opportunist
+Murder
+Pilfering Imp
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/N'er-do-wells-(2).txt
+++ b/library/Foundations/N'er-do-wells-(2).txt
@@ -1,0 +1,15 @@
+Rev, Tithe Extractor
+Thieves' Guild Enforcer
+Grim Bounty
+Thieves' Tools
+Audacious Thief
+Balustrade Spy
+Bloodtithe Collector
+Expedition Skulker
+Fake Your Own Death
+Foul Play
+Masked Blackguard
+Morbid Opportunist
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Nefarious.txt
+++ b/library/Foundations/Nefarious.txt
@@ -1,0 +1,15 @@
+Vilis, Broker of Blood
+Dark Confidant
+Scourge of the Undercity
+Howling Banshee
+Alchemist's Gift
+Arrogant Outlaw
+Audacious Thief
+Infernal Grasp
+Read the Bones
+Ulcerate
+Vampire Scrivener
+Metalspinner's Puzzleknot
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Ninjas.txt
+++ b/library/Foundations/Ninjas.txt
@@ -1,0 +1,15 @@
+Taeko, the Patient Avalanche
+Starlight Snare
+Ninja of the Deep Hours
+Fading Hope
+Moon-Circuit Hacker
+Moonsnare Specialist
+Network Disruptor
+Nightveil Sprite
+Phantom Ninja
+Prosperous Thief
+Smoke Shroud
+Whirlwind Denial
+Thriving Isle
+7 Island
+

--- a/library/Foundations/Of-the Coast (1).txt
+++ b/library/Foundations/Of-the Coast (1).txt
@@ -1,0 +1,16 @@
+Plagon, Lord of the Beach
+Delightful Discovery
+Gilded Scuttler
+Starlight Snare
+Run Ashore
+Kapsho Kitefins
+Omen of the Sea
+Purple-Crystal Crab
+Shorecomber Crab
+Sigiled Starfish
+Tidepool Turtle
+Yarok's Wavecrasher
+Lonely Sandbar
+Thriving Isle
+6 Island
+

--- a/library/Foundations/Of-the Coast (2).txt
+++ b/library/Foundations/Of-the Coast (2).txt
@@ -1,0 +1,16 @@
+Plagon, Lord of the Beach
+Delightful Discovery
+Gilded Scuttler
+Starlight Snare
+Run Ashore
+Azure Drake
+Glimmerbell
+Opt
+Shipwreck Dowser
+Shorecomber Crab
+Sigiled Starfish
+Tidepool Turtle
+Lonely Sandbar
+Thriving Isle
+6 Island
+

--- a/library/Foundations/Prideful.txt
+++ b/library/Foundations/Prideful.txt
@@ -1,0 +1,15 @@
+Brimaz, King of Oreskos
+Dawnwing Marshal
+Leonin Scimitar
+Basri's Acolyte
+Impeccable Timing
+Ingenious Leonin
+King of the Pride
+Leonin of the Lost Pride
+Leonin Vanguard
+Pacifism
+Savannah Lions
+Take Up the Shield
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Snakes.txt
+++ b/library/Foundations/Snakes.txt
@@ -1,0 +1,15 @@
+Aphelia, Viper Whisperer
+Hooded Blightfang
+Scourge of the Undercity
+Killing Glare
+Serpent Assassin
+Coat with Venom
+Night's Whisper
+Pharika's Chosen
+Ukud Cobra
+Venomous Hierophant
+Vraska's Finisher
+Gorgon Flail
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Soaring-(1).txt
+++ b/library/Foundations/Soaring-(1).txt
@@ -1,0 +1,15 @@
+Windreader Sphinx
+Starlight Snare
+Cynette, Jelly Drover
+Uncomfortable Chill
+Aerial Guide
+Gust of Wind
+Nightveil Sprite
+Serpentine Ambush
+Tide Skimmer
+Warden of Evos Isle
+Waterkin Shaman
+Winged Words
+Thriving Isle
+7 Island
+

--- a/library/Foundations/Soaring-(2).txt
+++ b/library/Foundations/Soaring-(2).txt
@@ -1,0 +1,15 @@
+Cavalier of Gales
+Starlight Snare
+Cynette, Jelly Drover
+Aerial Guide
+Cartouche of Knowledge
+Gust of Wind
+Majestic Metamorphosis
+Owl Familiar
+Shorecomber Crab
+Tide Skimmer
+Trial of Knowledge
+Warden of Evos Isle
+Thriving Isle
+7 Island
+

--- a/library/Foundations/Soaring-(3).txt
+++ b/library/Foundations/Soaring-(3).txt
@@ -1,0 +1,15 @@
+Mu Yanling, Sky Dancer
+Starlight Snare
+Cynette, Jelly Drover
+Aerial Guide
+Cloudkin Seer
+Gust of Wind
+Malcator's Watcher
+Serpentine Ambush
+Thopter Mechanic
+Tide Skimmer
+Windstorm Drake
+Winged Words
+Thriving Isle
+7 Island
+

--- a/library/Foundations/Soaring-(4).txt
+++ b/library/Foundations/Soaring-(4).txt
@@ -1,0 +1,15 @@
+Sprite Noble
+Stolen by the Fae
+Starlight Snare
+Cynette, Jelly Drover
+Faerie Seer
+Aerial Guide
+Air Elemental
+Majestic Metamorphosis
+Nightveil Sprite
+Opt
+Tide Skimmer
+Winged Words
+Thriving Isle
+7 Island
+

--- a/library/Foundations/Stalwart-(1).txt
+++ b/library/Foundations/Stalwart-(1).txt
@@ -1,0 +1,15 @@
+Generous Pup
+Ajani, Adversary of Tyrants
+Urdnan, Dromoka Warrior
+Banishing Light
+Angelic Cub
+Gavony Silversmith
+Patron of the Valiant
+Sandsteppe Outcast
+Squad Captain
+Steadfast Sentry
+Swift Response
+Take Up the Shield
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Stalwart-(2).txt
+++ b/library/Foundations/Stalwart-(2).txt
@@ -1,0 +1,16 @@
+Basri's Lieutenant
+Urdnan, Dromoka Warrior
+Banishing Light
+Basri's Acolyte
+Basri's Solidarity
+Battlefield Promotion
+Lightwalker
+Patron of the Valiant
+Sandsteppe Outcast
+Star Pupil
+Steadfast Sentry
+Swift Response
+Cave of Temptation
+Thriving Heath
+6 Plains
+

--- a/library/Foundations/Stalwart-(3).txt
+++ b/library/Foundations/Stalwart-(3).txt
@@ -1,0 +1,15 @@
+Generous Pup
+Urdnan, Dromoka Warrior
+Banishing Light
+Steadfast Unicorn
+Expedition Raptor
+Jubilant Mascot
+Paladin of the Bloodstained
+Relief Captain
+Sandsteppe Outcast
+Shoulder to Shoulder
+Swift Response
+Take Up the Shield
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Stalwart-(4).txt
+++ b/library/Foundations/Stalwart-(4).txt
@@ -1,0 +1,15 @@
+Light of the Legion
+Mikaeus, the Lunarch
+Urdnan, Dromoka Warrior
+Banishing Light
+Battlefield Promotion
+Gavony Silversmith
+Gird for Battle
+Parhelion Patrol
+Sandsteppe Outcast
+Steadfast Sentry
+Sunhome Stalwart
+Swift Response
+Thriving Heath
+7 Plains
+

--- a/library/Foundations/Stoked-(1).txt
+++ b/library/Foundations/Stoked-(1).txt
@@ -1,0 +1,15 @@
+Frontline Heroism
+Hearts on Fire
+Scholar of Combustion
+Cleon, Merry Champion
+Kiln Fiend
+Arena Athlete
+Resistance Skywarden
+Roil Eruption
+Satyr Hoplite
+Titan's Strength
+Twinferno
+Uncaged Fury
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Stoked-(2).txt
+++ b/library/Foundations/Stoked-(2).txt
@@ -1,0 +1,15 @@
+Dreadhorde Arcanist
+Hearts on Fire
+Cleon, Merry Champion
+Kiln Fiend
+Arena Athlete
+Coordinated Assault
+Hero of the Games
+Resistance Skywarden
+Roil Eruption
+Satyr Hoplite
+Titan's Strength
+Unleash Fury
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Stoked-(3).txt
+++ b/library/Foundations/Stoked-(3).txt
@@ -1,0 +1,15 @@
+Frontline Heroism
+Mirrorwing Dragon
+Hearts on Fire
+Scholar of Combustion
+Cleon, Merry Champion
+Akroan Crusader
+Arena Athlete
+Roil Eruption
+Titan's Strength
+Twinferno
+Unleash Fury
+Young Pyromancer
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Stoked-(4).txt
+++ b/library/Foundations/Stoked-(4).txt
@@ -1,0 +1,15 @@
+Goblin Dark-Dwellers
+Hearts on Fire
+Cleon, Merry Champion
+Akroan Crusader
+Arena Athlete
+Crimson Wisps
+Hero of the Games
+Infuriate
+Roil Eruption
+Uncaged Fury
+Weaver of Lightning
+Young Pyromancer
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Surprise!-(1).txt
+++ b/library/Foundations/Surprise!-(1).txt
@@ -1,0 +1,15 @@
+Thryx, the Sudden Storm
+Delightful Discovery
+Brineborn Cutthroat
+Capture Sphere
+Chrome Prowler
+Crystacean
+Opt
+Slimebind
+Spectral Sailor
+Stinging Lionfish
+Undersea Invader
+Wind Strider
+Thriving Isle
+7 Island
+

--- a/library/Foundations/Surprise!-(2).txt
+++ b/library/Foundations/Surprise!-(2).txt
@@ -1,0 +1,15 @@
+Thryx, the Sudden Storm
+Voracious Greatshark
+Delightful Discovery
+Brineborn Cutthroat
+Capture Sphere
+Naiad of Hidden Coves
+Opt
+Pestermite
+Spectral Sailor
+Starlit Mantle
+Stinging Lionfish
+Undersea Invader
+Thriving Isle
+7 Island
+

--- a/library/Foundations/Surprise!-(3).txt
+++ b/library/Foundations/Surprise!-(3).txt
@@ -1,0 +1,15 @@
+Venser, Shaper Savant
+Starlight Snare
+Breaching Hippocamp
+Brineborn Cutthroat
+Naiad of Hidden Coves
+Opt
+Pestermite
+Spectral Sailor
+Starlit Mantle
+Stinging Lionfish
+Supreme Will
+Wind Strider
+Thriving Isle
+7 Island
+

--- a/library/Foundations/Surprise!-(4).txt
+++ b/library/Foundations/Surprise!-(4).txt
@@ -1,0 +1,15 @@
+Venser, Shaper Savant
+Wavebreak Hippocamp
+Starlight Snare
+Uncomfortable Chill
+Aven Reedstalker
+Brineborn Cutthroat
+Fading Hope
+Soul Read
+Spectral Sailor
+Stinging Lionfish
+Vexing Gull
+Wind Strider
+Thriving Isle
+7 Island
+

--- a/library/Foundations/Too-Many.txt
+++ b/library/Foundations/Too-Many.txt
@@ -1,0 +1,14 @@
+Fiendish Duo
+Goblin Surprise
+2 Brothers Yamazaki
+Battle-Rattle Shaman
+Krenko's Command
+Furious Reprisal
+Mogg Flunkies
+Pigment Storm
+Reckless Impulse
+Twinferno
+Weaselback Redcap
+Thriving Bluff
+6 Mountain
+

--- a/library/Foundations/Treasures-(1).txt
+++ b/library/Foundations/Treasures-(1).txt
@@ -1,0 +1,15 @@
+Evereth, Viceroy of Plunder
+Ruthless Technomancer
+Deadly Dispute
+Grim Bounty
+Shambling Ghast
+Bastion of Remembrance
+Dire Fleet Hoarder
+Fake Your Own Death
+Pitiless Plunderer
+Reassembling Skeleton
+Ruthless Knave
+Undercity Scrounger
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Treasures-(2).txt
+++ b/library/Foundations/Treasures-(2).txt
@@ -1,0 +1,16 @@
+Evereth, Viceroy of Plunder
+Deadly Dispute
+Shambling Ghast
+Contract Killing
+Dire Fleet Hoarder
+Dusk Mangler
+Fake Your Own Death
+Pitiless Plunderer
+Powerstone Fracture
+Reassembling Skeleton
+Ruthless Knave
+Undercity Scrounger
+Thriving Moor
+Vault of Whispers
+6 Swamp
+

--- a/library/Foundations/Vampires-(1).txt
+++ b/library/Foundations/Vampires-(1).txt
@@ -1,0 +1,15 @@
+Sangromancer
+Scourge of the Undercity
+Nazar, the Velvet Fang
+Skymarch Bloodletter
+Bleed Dry
+Blood Burglar
+Blood Fountain
+Bloodtithe Collector
+Gift of Fangs
+Gluttonous Guest
+Urge to Feed
+Vampire of the Dire Moon
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Vampires-(2).txt
+++ b/library/Foundations/Vampires-(2).txt
@@ -1,0 +1,15 @@
+Crossway Troublemakers
+Sanctum Seeker
+Scourge of the Undercity
+Nazar, the Velvet Fang
+Alchemist's Gift
+Bleed Dry
+Blood Fountain
+Bloodthirsty Aerialist
+Creeping Bloodsucker
+Gluttonous Guest
+Urge to Feed
+Vampire of the Dire Moon
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Vampires-(3).txt
+++ b/library/Foundations/Vampires-(3).txt
@@ -1,0 +1,15 @@
+Necropolis Regent
+Scourge of the Undercity
+Nazar, the Velvet Fang
+Skymarch Bloodletter
+Bleed Dry
+Blood Fountain
+Creeping Bloodsucker
+Gift of Fangs
+Gluttonous Guest
+Go for the Throat
+Thirsting Bloodlord
+Vicious Conquistador
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Vampires-(4).txt
+++ b/library/Foundations/Vampires-(4).txt
@@ -1,0 +1,15 @@
+Rodolf Duskbringer
+Scourge of the Undercity
+Nazar, the Velvet Fang
+Bleed Dry
+Blood Burglar
+Blood Fountain
+Epicure of Blood
+Exsanguinate
+Gluttonous Guest
+Moment of Craving
+Vampire Nighthawk
+Vampire of the Dire Moon
+Thriving Moor
+7 Swamp
+

--- a/library/Foundations/Warriors-(1).txt
+++ b/library/Foundations/Warriors-(1).txt
@@ -1,0 +1,16 @@
+Gornog, the Red Reaper
+Ghitu Encampment
+Boggart Brute
+Boldwyr Intimidator
+Expedition Champion
+Goma Fada Vanguard
+Keldon Raider
+Kindled Fury
+Kruin Striker
+Pyrophobia
+Soul Sear
+Wrecking Crew
+Relic Axe
+Thriving Bluff
+6 Mountain
+

--- a/library/Foundations/Warriors-(2).txt
+++ b/library/Foundations/Warriors-(2).txt
@@ -1,0 +1,16 @@
+Gornog, the Red Reaper
+Kargan Intimidator
+Ghitu Encampment
+Boldwyr Intimidator
+Daybreak Combatants
+Goma Fada Vanguard
+Infuriate
+Keldon Raider
+Pyrophobia
+Soul Sear
+Unstoppable Ogre
+Wrecking Crew
+Relic Axe
+Thriving Bluff
+6 Mountain
+

--- a/library/Foundations/Wizards-(1).txt
+++ b/library/Foundations/Wizards-(1).txt
@@ -1,0 +1,15 @@
+Naban, Dean of Iteration
+Starlight Snare
+Faerie Seer
+Academy Journeymage
+Archaeomancer
+Augur of Bolas
+Choking Tethers
+Cloudkin Seer
+Concentrate
+Exclusion Mage
+Remand
+Windcaller Aven
+Thriving Isle
+7 Island
+

--- a/library/Foundations/Wizards-(2).txt
+++ b/library/Foundations/Wizards-(2).txt
@@ -1,0 +1,15 @@
+Naban, Dean of Iteration
+Aether Channeler
+Starlight Snare
+Faerie Seer
+Academy Journeymage
+Augur of Bolas
+Chilling Trap
+Expedition Diviner
+Frost Trickster
+Opportunity
+Remand
+Shipwreck Dowser
+Thriving Isle
+7 Island
+

--- a/library/Foundations/Zealots-(1).txt
+++ b/library/Foundations/Zealots-(1).txt
@@ -1,0 +1,16 @@
+Zealous Conscripts
+Anep, Vizier of Hazoret
+Ahn-Crop Crasher
+Battlefield Scavenger
+Bloodlust Inciter
+Brute Strength
+Cartouche of Zeal
+Emberhorn Minotaur
+Flame-Blessed Bolt
+Fling
+Nef-Crop Entangler
+Trial of Zeal
+Desert of the Fervent
+Thriving Bluff
+6 Mountain
+

--- a/library/Foundations/Zealots-(2).txt
+++ b/library/Foundations/Zealots-(2).txt
@@ -1,0 +1,15 @@
+Sandstorm Crasher
+Anep, Vizier of Hazoret
+Ahn-Crop Crasher
+Battlefield Scavenger
+Bloodlust Inciter
+Cartouche of Zeal
+Flame-Blessed Bolt
+Fling
+Kindled Fury
+Pathmaker Initiate
+Trial of Zeal
+Zealot of the God-Pharaoh
+Thriving Bluff
+7 Mountain
+

--- a/library/Foundations/Zealots-(3).txt
+++ b/library/Foundations/Zealots-(3).txt
@@ -1,0 +1,16 @@
+Combat Celebrant
+Hearts on Fire
+Anep, Vizier of Hazoret
+Battlefield Scavenger
+Bloodlust Inciter
+Cartouche of Zeal
+Emberhorn Minotaur
+Fling
+Nef-Crop Entangler
+Shock
+Trial of Zeal
+Trueheart Twins
+Desert of the Fervent
+Thriving Bluff
+6 Mountain
+

--- a/library/Foundations/Zealots-(4).txt
+++ b/library/Foundations/Zealots-(4).txt
@@ -1,0 +1,15 @@
+Sandstorm Crasher
+Zealous Conscripts
+Anep, Vizier of Hazoret
+Battlefield Scavenger
+Bloodlust Inciter
+Cartouche of Zeal
+Fling
+Kindled Fury
+Minotaur Sureshot
+Nef-Crop Entangler
+Trial of Zeal
+Trueheart Twins
+Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Blink-(1).txt
+++ b/library/Jumpstart 2022/Blink-(1).txt
@@ -1,0 +1,15 @@
+1 Preston, the Vanisher
+1 Distinguished Conjurer
+1 Brightmare
+1 Wispweaver Angel
+1 Faith's Fetters
+1 Flicker of Fate
+1 Thraben Inspector
+1 Inspiring Overseer
+1 Gallant Cavalry
+1 Rambunctious Mutt
+1 Acrobatic Maneuver
+1 Settle Beyond Reality
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Blink-(2).txt
+++ b/library/Jumpstart 2022/Blink-(2).txt
@@ -1,0 +1,15 @@
+1 Emiel the Blessed
+1 Distinguished Conjurer
+1 Brightmare
+1 Imperial Aerosaur
+1 Faith's Fetters
+1 Flicker of Fate
+1 Daybreak Charger
+1 Inspiring Overseer
+1 Valorous Steed
+1 Rambunctious Mutt
+1 Justiciar's Portal
+1 Settle Beyond Reality
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Blink-(3).txt
+++ b/library/Jumpstart 2022/Blink-(3).txt
@@ -1,0 +1,15 @@
+1 Restoration Angel
+1 Preston, the Vanisher
+1 Distinguished Conjurer
+1 Brightmare
+1 Valor in Akros
+1 Faith's Fetters
+1 Flicker of Fate
+1 Cavalry Drillmaster
+1 Inspiring Overseer
+1 Valorous Steed
+1 Rambunctious Mutt
+1 Settle Beyond Reality
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Blink-(4).txt
+++ b/library/Jumpstart 2022/Blink-(4).txt
@@ -1,0 +1,15 @@
+1 Panharmonicon
+1 Distinguished Conjurer
+1 Pierce Strider
+1 Wispweaver Angel
+1 Faith's Fetters
+1 Flicker of Fate
+1 Cavalry Drillmaster
+1 Brightmare
+1 Inspiring Overseer
+1 Seller of Songbirds
+1 Rambunctious Mutt
+1 Settle Beyond Reality
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Boneyard-(1).txt
+++ b/library/Jumpstart 2022/Boneyard-(1).txt
@@ -1,0 +1,15 @@
+1 Oversold Cemetery
+1 Ossuary Rats
+1 Stitcher's Supplier
+1 Revenant
+1 Necrotic Wound
+1 Suspicious Shambler
+1 Wailing Ghoul
+1 Pit Keeper
+1 Spark Reaper
+1 Gorging Vulture
+1 Moodmark Painter
+1 Corpse Churn
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Boneyard-(2).txt
+++ b/library/Jumpstart 2022/Boneyard-(2).txt
@@ -1,0 +1,15 @@
+1 Shadowborn Demon
+1 Graveblade Marauder
+1 Ossuary Rats
+1 Stitcher's Supplier
+1 Liliana's Elite
+1 Necrotic Wound
+1 Suspicious Shambler
+1 Ghoul's Feast
+1 Wailing Ghoul
+1 Gorging Vulture
+1 Moodmark Painter
+1 Corpse Churn
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Cats-(1).txt
+++ b/library/Jumpstart 2022/Cats-(1).txt
@@ -1,0 +1,15 @@
+1 Regal Caracal
+1 Ingenious Leonin
+1 King of the Pride
+1 Savannah Lions
+1 Make a Stand
+1 Leonin Snarecaster
+1 Felidar Cub
+1 Basri's Acolyte
+1 Skyhunter Patrol
+1 Leonin Scimitar
+1 Impeccable Timing
+1 Weight of Conscience
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Cats-(2).txt
+++ b/library/Jumpstart 2022/Cats-(2).txt
@@ -1,0 +1,15 @@
+1 Felidar Retreat
+1 Trove Warden
+1 Ingenious Leonin
+1 King of the Pride
+1 Savannah Lions
+1 Make a Stand
+1 Steppe Lynx
+1 Mesa Lynx
+1 Leonin Snarecaster
+1 Prowling Felidar
+1 Impeccable Timing
+1 Weight of Conscience
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Cats-(3).txt
+++ b/library/Jumpstart 2022/Cats-(3).txt
@@ -1,0 +1,15 @@
+1 Ajani, Strength of the Pride
+1 Ingenious Leonin
+1 King of the Pride
+1 Ajani's Pridemate
+1 Make a Stand
+1 Trained Caracal
+1 Leonin Snarecaster
+1 Savannah Sage
+1 Basri's Acolyte
+1 Leonin Scimitar
+1 Impeccable Timing
+1 Weight of Conscience
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Cats-(4).txt
+++ b/library/Jumpstart 2022/Cats-(4).txt
@@ -1,0 +1,15 @@
+1 Leonin Warleader
+1 Ingenious Leonin
+1 King of the Pride
+1 Savannah Lions
+1 Make a Stand
+1 Leonin Snarecaster
+1 Pouncing Lynx
+1 Skyhunter Prowler
+1 Basri's Acolyte
+1 Leonin Scimitar
+1 Impeccable Timing
+1 Weight of Conscience
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Constellation-(1).txt
+++ b/library/Jumpstart 2022/Constellation-(1).txt
@@ -1,0 +1,15 @@
+1 Archon of Sun's Grace
+1 Sage's Reverie
+1 Blessed Spirits
+1 Favored of Iroas
+1 Spectral Steel
+1 Chains of Custody
+1 Glory Bearers
+1 Transcendent Envoy
+1 Captivating Unicorn
+1 Forced Worship
+1 Pious Wayfarer
+1 Spirited Companion
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Constellation-(2).txt
+++ b/library/Jumpstart 2022/Constellation-(2).txt
@@ -1,0 +1,15 @@
+1 Sigil of the Empty Throne
+1 Sage's Reverie
+1 Blessed Spirits
+1 Spectral Steel
+1 Alseid of Life's Bounty
+1 Chains of Custody
+1 Transcendent Envoy
+1 Auramancer
+1 Glory Bearers
+1 Captivating Unicorn
+1 Dreadful Apathy
+1 Spirited Companion
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Cruel-(1).txt
+++ b/library/Jumpstart 2022/Cruel-(1).txt
@@ -1,0 +1,15 @@
+1 Termination Facilitator
+1 Feast on the Fallen
+1 Syr Konrad, the Grim
+1 Talon of Pain
+1 Ob Nixilis, the Hate-Twisted
+1 Infernal Idol
+1 Ossuary Rats
+1 Creeping Bloodsucker
+1 Tormented Soul
+1 Alley Strangler
+1 Wicked Guardian
+1 Ob Nixilis's Cruelty
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Cruel-(2).txt
+++ b/library/Jumpstart 2022/Cruel-(2).txt
@@ -1,0 +1,15 @@
+1 Termination Facilitator
+1 Feast on the Fallen
+1 Plague Spitter
+1 Nested Ghoul
+1 Talon of Pain
+1 Creeping Bloodsucker
+1 Ossuary Rats
+1 Infernal Idol
+1 Alley Strangler
+1 Lurking Deadeye
+1 Mire Blight
+1 Consign to the Pit
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Cruel-(3).txt
+++ b/library/Jumpstart 2022/Cruel-(3).txt
@@ -1,0 +1,15 @@
+1 Cruel Sadist
+1 Dread Slaver
+1 Conductor of Cacophony
+1 Feast on the Fallen
+1 Festering Evil
+1 Talon of Pain
+1 Infernal Idol
+1 Ossuary Rats
+1 Creeping Bloodsucker
+1 Hooded Assassin
+1 Alley Strangler
+1 Mire Blight
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Cruel-(4).txt
+++ b/library/Jumpstart 2022/Cruel-(4).txt
@@ -1,0 +1,15 @@
+1 Dread Presence
+1 Conductor of Cacophony
+1 Feast on the Fallen
+1 Nested Ghoul
+1 Talon of Pain
+1 Ossuary Rats
+1 Infernal Idol
+1 Creeping Bloodsucker
+1 Tormented Soul
+1 Hooded Assassin
+1 Alley Strangler
+1 Mire Blight
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Cycling-(1).txt
+++ b/library/Jumpstart 2022/Cycling-(1).txt
@@ -1,0 +1,16 @@
+1 Yidaro, Wandering Monster
+1 Flameblade Adept
+1 Rooting Moloch
+1 Reptilian Reflection
+1 Deem Worthy
+1 Drannith Stinger
+1 Prickly Marmoset
+1 Quakefoot Cyclops
+1 Plundering Predator
+1 Lava Serpent
+1 Go for Blood
+1 Shredded Sails
+1 Forgotten Cave
+1 Thriving Bluff
+6 Mountain
+

--- a/library/Jumpstart 2022/Cycling-(2).txt
+++ b/library/Jumpstart 2022/Cycling-(2).txt
@@ -1,0 +1,16 @@
+1 Irencrag Pyromancer
+1 Starstorm
+1 Deem Worthy
+1 Mad Ratter
+1 Rooting Moloch
+1 Reptilian Reflection
+1 Drannith Stinger
+1 Bloodhaze Wolverine
+1 Prickly Marmoset
+1 Plundering Predator
+1 Go for Blood
+1 Raking Claws
+1 Forgotten Cave
+1 Thriving Bluff
+6 Mountain
+

--- a/library/Jumpstart 2022/Demons-(1).txt
+++ b/library/Jumpstart 2022/Demons-(1).txt
@@ -1,0 +1,15 @@
+1 Kothophed, Soul Hoarder
+1 Conductor of Cacophony
+1 Disciple of Perdition
+1 Demon's Disciple
+1 Inner Demon
+1 Infernal Idol
+1 Diabolic Edict
+1 Renegade Demon
+1 Takenuma Bleeder
+1 Fetid Imp
+1 Soulcage Fiend
+1 Demon's Grasp
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Demons-(2).txt
+++ b/library/Jumpstart 2022/Demons-(2).txt
@@ -1,0 +1,15 @@
+1 Demon of Catastrophes
+1 Seizan, Perverter of Truth
+1 Conductor of Cacophony
+1 Disciple of Perdition
+1 Demon's Disciple
+1 Dreadhound
+1 Infernal Idol
+1 Diabolic Edict
+1 Doomed Dissenter
+1 Takenuma Bleeder
+1 Demonic Gifts
+1 Demon's Grasp
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Detective-(1).txt
+++ b/library/Jumpstart 2022/Detective-(1).txt
@@ -1,0 +1,15 @@
+1 Mechanized Production
+1 Hold for Questioning
+1 Magnifying Glass
+1 Shambling Suit
+1 Filigree Attendant
+1 Dutiful Replicator
+1 Floodhound
+1 Vedalken Engineer
+1 Drownyard Explorers
+1 Gearseeker Serpent
+1 Press for Answers
+1 Jace's Scrutiny
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Detective-(2).txt
+++ b/library/Jumpstart 2022/Detective-(2).txt
@@ -1,0 +1,15 @@
+1 Teferi's Puzzle Box
+1 Psychosis Crawler
+1 Hold for Questioning
+1 Magnifying Glass
+1 Oneirophage
+1 Tolarian Kraken
+1 Floodhound
+1 Vedalken Engineer
+1 Aeronaut Tinkerer
+1 Drownyard Explorers
+1 Press for Answers
+1 Jace's Scrutiny
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Detective-(3).txt
+++ b/library/Jumpstart 2022/Detective-(3).txt
@@ -1,0 +1,15 @@
+1 Shimmer Dragon
+1 Hold for Questioning
+1 Magnifying Glass
+1 Lumengrid Sentinel
+1 Skilled Animator
+1 Dutiful Replicator
+1 Floodhound
+1 Vedalken Engineer
+1 Drownyard Explorers
+1 Weldfast Wingsmith
+1 Press for Answers
+1 Jace's Scrutiny
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Detective-(4).txt
+++ b/library/Jumpstart 2022/Detective-(4).txt
@@ -1,0 +1,15 @@
+1 Tamiyo, the Moon Sage
+1 Tamiyo's Journal
+1 Hold for Questioning
+1 Magnifying Glass
+1 Erdwal Illuminator
+1 Syr Elenora, the Discerning
+1 Dutiful Replicator
+1 Floodhound
+1 Vedalken Engineer
+1 Drownyard Explorers
+1 Press for Answers
+1 Jace's Scrutiny
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Dragons-(1).txt
+++ b/library/Jumpstart 2022/Dragons-(1).txt
@@ -1,0 +1,15 @@
+1 Sarkhan, the Dragonspeaker
+1 Sarkhan's Whelp
+1 Dragon Egg
+1 Furnace Whelp
+1 Dragon Mage
+1 Dragon Fodder
+1 Kargan Dragonrider
+1 Bogardan Dragonheart
+1 Plundering Predator
+1 Tormenting Voice
+1 Scorching Dragonfire
+1 Sarkhan's Rage
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Dragons-(2).txt
+++ b/library/Jumpstart 2022/Dragons-(2).txt
@@ -1,0 +1,15 @@
+1 Lathliss, Dragon Queen
+1 Dragon's Hoard
+1 Dragonlord's Servant
+1 Dragonspeaker Shaman
+1 Furnace Whelp
+1 Dragon Mage
+1 Kargan Dragonrider
+1 Plundering Predator
+1 Sparktongue Dragon
+1 Scorching Dragonfire
+1 Tormenting Voice
+1 Sarkhan's Rage
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Eldrazi.txt
+++ b/library/Jumpstart 2022/Eldrazi.txt
@@ -1,0 +1,17 @@
+1 World Breaker
+1 Endbringer
+1 Brood Monitor
+1 Ruin in Their Wake
+1 Planar Atlas
+1 Titan's Presence
+1 Blisterpod
+1 Stalking Drone
+1 Scion Summoner
+1 Warden of Geometries
+1 Ancient Stirrings
+1 Unnatural Aggression
+1 Warped Landscape
+1 Ash Barrens
+1 Wastes
+5 Forest
+

--- a/library/Jumpstart 2022/Elves-(1).txt
+++ b/library/Jumpstart 2022/Elves-(1).txt
@@ -1,0 +1,15 @@
+1 Elvish Warmaster
+1 Dwynen's Elite
+1 Reclamation Sage
+1 Primeval Herald
+1 Elven Bow
+1 Reckless Amplimancer
+1 Elvish Rejuvenator
+1 Ivy Lane Denizen
+1 Elderleaf Mentor
+1 Might of the Masses
+1 Roots of Wisdom
+1 Band Together
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Elves-(2).txt
+++ b/library/Jumpstart 2022/Elves-(2).txt
@@ -1,0 +1,15 @@
+1 Imperious Perfect
+1 Dwynen's Elite
+1 Ghirapur Guide
+1 Primeval Herald
+1 Elven Bow
+1 Reckless Amplimancer
+1 Elvish Rejuvenator
+1 Ivy Lane Denizen
+1 Elderleaf Mentor
+1 Might of the Masses
+1 Roots of Wisdom
+1 Band Together
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Elves-(3).txt
+++ b/library/Jumpstart 2022/Elves-(3).txt
@@ -1,0 +1,15 @@
+1 Wolverine Riders
+1 Woodland Champion
+1 Dwynen's Elite
+1 Elven Bow
+1 Instruments of War
+1 Elvish Rejuvenator
+1 Ivy Lane Denizen
+1 Elderleaf Mentor
+1 Lys Alana Huntmaster
+1 Might of the Masses
+1 Roots of Wisdom
+1 Band Together
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Elves-(4).txt
+++ b/library/Jumpstart 2022/Elves-(4).txt
@@ -1,0 +1,15 @@
+1 Wildborn Preserver
+1 Woodland Champion
+1 Dwynen's Elite
+1 Elven Bow
+1 Overcome
+1 Elvish Rejuvenator
+1 Dutiful Replicator
+1 Ivy Lane Denizen
+1 Elderleaf Mentor
+1 Roots of Wisdom
+1 Presence of Gond
+1 Band Together
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Experimental-(1).txt
+++ b/library/Jumpstart 2022/Experimental-(1).txt
@@ -1,0 +1,15 @@
+1 Ignite the Future
+1 Mizzix, Replica Rider
+1 Young Pyromancer
+1 Grotag Night-Runner
+1 Seize the Storm
+1 Lightning Axe
+1 Thermo-Alchemist
+1 Spellgorger Weird
+1 Catalyst Elemental
+1 Goblin Researcher
+1 Firebolt
+1 Electric Revelation
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Experimental-(2).txt
+++ b/library/Jumpstart 2022/Experimental-(2).txt
@@ -1,0 +1,15 @@
+1 Mizzix, Replica Rider
+1 Grotag Night-Runner
+1 Cyclops Electromancer
+1 Spark of Creativity
+1 Act on Impulse
+1 Thermo-Alchemist
+1 Sparkmage Apprentice
+1 Catalyst Elemental
+1 Goblin Researcher
+1 Firebolt
+1 Electric Revelation
+1 Electrify
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Faeries-(1).txt
+++ b/library/Jumpstart 2022/Faeries-(1).txt
@@ -1,0 +1,15 @@
+1 Vendilion Clique
+1 Wavebreak Hippocamp
+1 Synchronized Eviction
+1 Instruments of War
+1 Brineborn Cutthroat
+1 Glen Elendra Pranksters
+1 Soul Read
+1 Spellstutter Sprite
+1 Pestermite
+1 Sentinels of Glen Elendra
+1 Undersea Invader
+1 Fleeting Distraction
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Faeries-(2).txt
+++ b/library/Jumpstart 2022/Faeries-(2).txt
@@ -1,0 +1,15 @@
+1 Stolen by the Fae
+1 Synchronized Eviction
+1 Instruments of War
+1 Stinging Lionfish
+1 Glen Elendra Pranksters
+1 Undersea Invader
+1 Soul Read
+1 Spellstutter Sprite
+1 Faerie Seer
+1 Pestermite
+1 Sentinels of Glen Elendra
+1 So Tiny
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Fangs-(1).txt
+++ b/library/Jumpstart 2022/Fangs-(1).txt
@@ -1,0 +1,15 @@
+1 Rodolf Duskbringer
+1 Oathsworn Vampire
+1 Feast of Blood
+1 Bloodthirsty Aerialist
+1 Falkenrath Noble
+1 Creeping Bloodsucker
+1 Marauding Blight-Priest
+1 Vampire Envoy
+1 Epicure of Blood
+1 Moment of Craving
+1 Ill-Gotten Inheritance
+1 Blood Price
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Fangs-(2).txt
+++ b/library/Jumpstart 2022/Fangs-(2).txt
@@ -1,0 +1,15 @@
+1 Rodolf Duskbringer
+1 Bloodtracker
+1 Oathsworn Vampire
+1 Bloodthirsty Aerialist
+1 Falkenrath Noble
+1 Vampiric Rites
+1 Creeping Bloodsucker
+1 Marauding Blight-Priest
+1 Vampire Envoy
+1 Moment of Craving
+1 Ill-Gotten Inheritance
+1 Certain Death
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Fangs-(3).txt
+++ b/library/Jumpstart 2022/Fangs-(3).txt
@@ -1,0 +1,15 @@
+1 Tivash, Gloom Summoner
+1 Oathsworn Vampire
+1 Blood Artist
+1 Bloodbond Vampire
+1 Ancient Craving
+1 Creeping Bloodsucker
+1 Vampire Envoy
+1 Marauding Blight-Priest
+1 Nirkana Assassin
+1 Moment of Craving
+1 Ill-Gotten Inheritance
+1 Certain Death
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Fangs-(4).txt
+++ b/library/Jumpstart 2022/Fangs-(4).txt
@@ -1,0 +1,15 @@
+1 Vito, Thorn of the Dusk Rose
+1 Oathsworn Vampire
+1 Blood Artist
+1 Feast of Blood
+1 Bloodbond Vampire
+1 Creeping Bloodsucker
+1 Vampire Envoy
+1 Marauding Blight-Priest
+1 Kalastria Nightwatch
+1 Moment of Craving
+1 Ill-Gotten Inheritance
+1 Blood Price
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Ferocious-(1).txt
+++ b/library/Jumpstart 2022/Ferocious-(1).txt
@@ -1,0 +1,15 @@
+1 Rhonas the Indomitable
+1 Challenger Troll
+1 Roar of Challenge
+1 Colossal Majesty
+1 Rampaging Growth
+1 Ilysian Caryatid
+1 Drowsing Tyrannodon
+1 Giant Ladybug
+1 Gaea's Protector
+1 Ornery Dilophosaur
+1 Spectral Hunt-Caller
+1 Savage Punch
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Ferocious-(2).txt
+++ b/library/Jumpstart 2022/Ferocious-(2).txt
@@ -1,0 +1,15 @@
+1 Goreclaw, Terror of Qal Sisma
+1 Nessian Hornbeetle
+1 Challenger Troll
+1 Roar of Challenge
+1 Colossal Majesty
+1 Ilysian Caryatid
+1 Drowsing Tyrannodon
+1 Giant Ladybug
+1 Gaea's Protector
+1 Spectral Hunt-Caller
+1 Rosethorn Halberd
+1 Savage Punch
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Ferocious-(3).txt
+++ b/library/Jumpstart 2022/Ferocious-(3).txt
@@ -1,0 +1,15 @@
+1 Prowling Serpopard
+1 Challenger Troll
+1 Hammer of Ruin
+1 Roar of Challenge
+1 Colossal Majesty
+1 Ilysian Caryatid
+1 Drowsing Tyrannodon
+1 Giant Ladybug
+1 Ornery Dilophosaur
+1 Bristling Boar
+1 Spectral Hunt-Caller
+1 Savage Punch
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Ferocious-(4).txt
+++ b/library/Jumpstart 2022/Ferocious-(4).txt
@@ -1,0 +1,16 @@
+1 Creeperhulk
+1 Bonders' Enclave
+1 Towering Gibbon
+1 Challenger Troll
+1 Roar of Challenge
+1 Colossal Majesty
+1 Ilysian Caryatid
+1 Drowsing Tyrannodon
+1 Frontier Mastodon
+1 Giant Ladybug
+1 Spectral Hunt-Caller
+1 Savage Punch
+1 Kitesail
+1 Thriving Grove
+6 Forest
+

--- a/library/Jumpstart 2022/Fiery-(1).txt
+++ b/library/Jumpstart 2022/Fiery-(1).txt
@@ -1,0 +1,15 @@
+1 Chandra, Flame's Fury
+1 Chandra's Pyreling
+1 Chandra's Spitfire
+1 Spiteful Prankster
+1 Coalborn Entity
+1 Chandra's Magmutt
+1 Goblin Researcher
+1 Wildfire Elemental
+1 Pillar of Flame
+1 Chandra's Pyrohelix
+1 Thrill of Possibility
+1 Fiery Intervention
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Fiery-(2).txt
+++ b/library/Jumpstart 2022/Fiery-(2).txt
@@ -1,0 +1,15 @@
+1 Magmatic Channeler
+1 Banefire
+1 Chandra's Pyreling
+1 Coalborn Entity
+1 Flames of the Firebrand
+1 Chandra's Spitfire
+1 Blisterspit Gremlin
+1 Goblin Researcher
+1 Wildfire Elemental
+1 Pillar of Flame
+1 Thrill of Possibility
+1 Fiery Intervention
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Fiery-(3).txt
+++ b/library/Jumpstart 2022/Fiery-(3).txt
@@ -1,0 +1,15 @@
+1 Ogre Battlecaster
+1 Chandra's Pyreling
+1 Chandra's Spitfire
+1 Dance with Devils
+1 Coalborn Entity
+1 Thermo-Alchemist
+1 Wildfire Elemental
+1 Pillar of Flame
+1 Thrill of Possibility
+1 Hungry Flames
+1 Flame Lash
+1 Fiery Intervention
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Fiery-(4).txt
+++ b/library/Jumpstart 2022/Fiery-(4).txt
@@ -1,0 +1,15 @@
+1 Ogre Battlecaster
+1 Chandra's Pyreling
+1 Chandra's Spitfire
+1 Coalborn Entity
+1 Cone of Flame
+1 Blisterspit Gremlin
+1 Viashino Pyromancer
+1 Wildfire Elemental
+1 Pillar of Flame
+1 Thrill of Possibility
+1 Searing Spear
+1 Fiery Intervention
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Gigantic-(1).txt
+++ b/library/Jumpstart 2022/Gigantic-(1).txt
@@ -1,0 +1,15 @@
+1 Runadi, Behemoth Caller
+1 Thrashing Brontodon
+1 Towering Gibbon
+1 Woodborn Behemoth
+1 Enlarge
+1 Naga Vitalist
+1 Ondu Giant
+1 Colossal Dreadmaw
+1 Havenwood Wurm
+1 Pounce
+1 Overgrowth
+1 Gift of the Gargantuan
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Gigantic-(2).txt
+++ b/library/Jumpstart 2022/Gigantic-(2).txt
@@ -1,0 +1,15 @@
+1 Runadi, Behemoth Caller
+1 Engulfing Slagwurm
+1 Paradise Druid
+1 Thrashing Brontodon
+1 Towering Gibbon
+1 Enlarge
+1 Colossal Dreadmaw
+1 Ondu Giant
+1 Mammoth Spider
+1 Prey Upon
+1 Overgrowth
+1 Gift of the Gargantuan
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Go-to School (1).txt
+++ b/library/Jumpstart 2022/Go-to School (1).txt
@@ -1,0 +1,15 @@
+1 Barrin, Tolarian Archmage
+1 Biblioplex Kraken
+1 Kasmina, Enigmatic Mentor
+1 Dismiss
+1 Overwhelmed Apprentice
+1 Merfolk Pupil
+1 Wizard Mentor
+1 Tragic Lesson
+1 Elite Instructor
+1 Tolarian Sentinel
+1 Academy Journeymage
+1 Bury in Books
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Go-to School (2).txt
+++ b/library/Jumpstart 2022/Go-to School (2).txt
@@ -1,0 +1,15 @@
+1 Rhystic Study
+1 Multiple Choice
+1 Biblioplex Kraken
+1 Kasmina, Enigmatic Mentor
+1 Overwhelmed Apprentice
+1 Dismiss
+1 Merfolk Pupil
+1 Campus Guide
+1 Teferi's Protege
+1 Elite Instructor
+1 Academy Journeymage
+1 Bury in Books
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Goblins-(1).txt
+++ b/library/Jumpstart 2022/Goblins-(1).txt
@@ -1,0 +1,15 @@
+1 Krenko, Mob Boss
+1 Hordeling Outburst
+1 Volley Veteran
+1 Battle Squadron
+1 Goblin Grenade
+1 Weaselback Redcap
+1 Dragon Fodder
+1 Subterranean Scout
+1 Rummaging Goblin
+1 Goblin Researcher
+1 Burn Bright
+1 Flame Lash
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Goblins-(2).txt
+++ b/library/Jumpstart 2022/Goblins-(2).txt
@@ -1,0 +1,15 @@
+1 Ib Halfheart, Goblin Tactician
+1 Goblin Warchief
+1 Volley Veteran
+1 Goblin Rally
+1 Goblin Grenade
+1 Frenzied Goblin
+1 Dragon Fodder
+1 Goblin Trailblazer
+1 Rummaging Goblin
+1 Goblin Researcher
+1 Burn Bright
+1 Flame Lash
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Goblins-(3).txt
+++ b/library/Jumpstart 2022/Goblins-(3).txt
@@ -1,0 +1,15 @@
+1 Muxus, Goblin Grandee
+1 Arms Dealer
+1 Volley Veteran
+1 Goblin Grenade
+1 Instruments of War
+1 Fanatical Firebrand
+1 Dragon Fodder
+1 Goblin Trailblazer
+1 Rummaging Goblin
+1 Goblin Researcher
+1 Burn Bright
+1 Destructive Tampering
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Goblins-(4).txt
+++ b/library/Jumpstart 2022/Goblins-(4).txt
@@ -1,0 +1,15 @@
+1 Ardoz, Cobbler of War
+1 Goblin Rabblemaster
+1 Hordeling Outburst
+1 Volley Veteran
+1 Goblin Rally
+1 Goblin Grenade
+1 Torch Courier
+1 Dragon Fodder
+1 Rummaging Goblin
+1 Goblin Researcher
+1 Outnumber
+1 Burn Bright
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Gross-(1).txt
+++ b/library/Jumpstart 2022/Gross-(1).txt
@@ -1,0 +1,16 @@
+1 Massacre Wurm
+1 Skullslither Worm
+1 Plaguecrafter
+1 Leechridden Swamp
+1 Yargle, Glutton of Urborg
+1 Infernal Idol
+1 Blight Keeper
+1 Black Cat
+1 Durable Coilbug
+1 Devouring Swarm
+1 Eaten Alive
+1 Grotesque Mutation
+1 Strangling Spores
+1 Thriving Moor
+6 Swamp
+

--- a/library/Jumpstart 2022/Gross-(2).txt
+++ b/library/Jumpstart 2022/Gross-(2).txt
@@ -1,0 +1,16 @@
+1 Phyrexian Plaguelord
+1 Plaguecrafter
+1 Skullslither Worm
+1 Phyrexian Reclamation
+1 Blighted Fen
+1 Blight Keeper
+1 Durable Coilbug
+1 Deathbloom Thallid
+1 Devouring Swarm
+1 Phyrexian Debaser
+1 Eaten Alive
+1 Fungal Infection
+1 Grotesque Mutation
+1 Thriving Moor
+6 Swamp
+

--- a/library/Jumpstart 2022/Gross-(3).txt
+++ b/library/Jumpstart 2022/Gross-(3).txt
@@ -1,0 +1,15 @@
+1 Deathbringer Regent
+1 Plaguecrafter
+1 Skullslither Worm
+1 Kraul Swarm
+1 Death Wind
+1 Blight Keeper
+1 Durable Coilbug
+1 Dune Beetle
+1 Devouring Swarm
+1 Eaten Alive
+1 Grotesque Mutation
+1 Infernal Idol
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Gross-(4).txt
+++ b/library/Jumpstart 2022/Gross-(4).txt
@@ -1,0 +1,15 @@
+1 Ophiomancer
+1 Plaguecrafter
+1 Skullslither Worm
+1 Swarm of Bloodflies
+1 Witch's Cauldron
+1 Blight Keeper
+1 Vermin Gorger
+1 Durable Coilbug
+1 Devouring Swarm
+1 Ossuary Rats
+1 Eaten Alive
+1 Grotesque Mutation
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Holy-(1).txt
+++ b/library/Jumpstart 2022/Holy-(1).txt
@@ -1,0 +1,15 @@
+1 Blessed Sanctuary
+1 Angelic Cub
+1 Emancipation Angel
+1 Goldnight Commander
+1 Miraculous Recovery
+1 Chains of Custody
+1 Angelic Page
+1 Pilgrim of the Ages
+1 Pillardrop Rescuer
+1 Anointer of Valor
+1 Light of Hope
+1 Divine Arrow
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Holy-(2).txt
+++ b/library/Jumpstart 2022/Holy-(2).txt
@@ -1,0 +1,15 @@
+1 Lyra Dawnbringer
+1 Angelic Cub
+1 Emancipation Angel
+1 Starnheim Aspirant
+1 Defy Death
+1 Chains of Custody
+1 Pilgrim of the Ages
+1 Stalwart Valkyrie
+1 Dawning Angel
+1 Anointer of Valor
+1 Light of Hope
+1 Divine Arrow
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Holy-(3).txt
+++ b/library/Jumpstart 2022/Holy-(3).txt
@@ -1,0 +1,15 @@
+1 Dawn of Hope
+1 Valkyrie Harbinger
+1 Planar Atlas
+1 Emancipation Angel
+1 Serene Steward
+1 Inspiring Cleric
+1 Chains of Custody
+1 Pilgrim of the Ages
+1 Dawning Angel
+1 Anointer of Valor
+1 Light of Hope
+1 Divine Arrow
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Holy-(4).txt
+++ b/library/Jumpstart 2022/Holy-(4).txt
@@ -1,0 +1,15 @@
+1 Righteous Valkyrie
+1 Emancipation Angel
+1 Inspiring Cleric
+1 Attended Healer
+1 Faith's Fetters
+1 Chains of Custody
+1 Daybreak Chaplain
+1 Pilgrim of the Ages
+1 Pillardrop Rescuer
+1 Anointer of Valor
+1 Light of Hope
+1 Divine Arrow
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Insects-(1).txt
+++ b/library/Jumpstart 2022/Insects-(1).txt
@@ -1,0 +1,15 @@
+1 Swarm Shambler
+1 Nessian Hornbeetle
+1 Nantuko Cultivator
+1 Iridescent Hornbeetle
+1 Crawling Sensation
+1 Caustic Caterpillar
+1 Ironshell Beetle
+1 Duskshell Crawler
+1 Giant Ladybug
+1 Moldgraf Millipede
+1 Relentless Pursuit
+1 Hunter's Edge
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Insects-(2).txt
+++ b/library/Jumpstart 2022/Insects-(2).txt
@@ -1,0 +1,15 @@
+1 Zask, Skittering Swarmlord
+1 Kraul Harpooner
+1 Circuit Mender
+1 Nantuko Cultivator
+1 Crawling Sensation
+1 Caustic Caterpillar
+1 Ironshell Beetle
+1 Giant Ladybug
+1 Kraul Foragers
+1 Moldgraf Millipede
+1 Relentless Pursuit
+1 Hunter's Edge
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Insects-(3).txt
+++ b/library/Jumpstart 2022/Insects-(3).txt
@@ -1,0 +1,15 @@
+1 Deadbridge Goliath
+1 Phantom Nantuko
+1 Nessian Hornbeetle
+1 Iridescent Hornbeetle
+1 Nantuko Cultivator
+1 Crawling Sensation
+1 Caustic Caterpillar
+1 Drudge Beetle
+1 Ironshell Beetle
+1 Giant Ladybug
+1 Relentless Pursuit
+1 Hunter's Edge
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Insects-(4).txt
+++ b/library/Jumpstart 2022/Insects-(4).txt
@@ -1,0 +1,15 @@
+1 Zask, Skittering Swarmlord
+1 Nantuko Cultivator
+1 Quarry Beetle
+1 Crawling Sensation
+1 Rampaging Growth
+1 Caustic Caterpillar
+1 Ironshell Beetle
+1 Kraul Warrior
+1 Giant Ladybug
+1 Giant Caterpillar
+1 Relentless Pursuit
+1 Hunter's Edge
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Inventive-(1).txt
+++ b/library/Jumpstart 2022/Inventive-(1).txt
@@ -1,0 +1,16 @@
+1 Tezzeret, Artifice Master
+1 Planar Atlas
+1 Launch Mishap
+1 Whirler Rogue
+1 Skilled Animator
+1 Merfolk Pupil
+1 Gearsmith Prodigy
+1 Aviation Pioneer
+1 Gearsmith Guardian
+1 Gearseeker Serpent
+1 Aether Spellbomb
+1 Artificer's Epiphany
+1 Thriving Isle
+1 Seat of the Synod
+6 Island
+

--- a/library/Jumpstart 2022/Inventive-(2).txt
+++ b/library/Jumpstart 2022/Inventive-(2).txt
@@ -1,0 +1,16 @@
+1 Hangarback Walker
+1 Launch Mishap
+1 Whirler Rogue
+1 Renowned Weaponsmith
+1 Juggernaut
+1 Gearsmith Prodigy
+1 Aeronaut Tinkerer
+1 Aviation Pioneer
+1 Gearseeker Serpent
+1 Heart-Piercer Bow
+1 Vial of Dragonfire
+1 Artificer's Epiphany
+1 Thriving Isle
+1 Seat of the Synod
+6 Island
+

--- a/library/Jumpstart 2022/Inventive-(3).txt
+++ b/library/Jumpstart 2022/Inventive-(3).txt
@@ -1,0 +1,16 @@
+1 Steel Overseer
+1 Thopter Spy Network
+1 Launch Mishap
+1 Whirler Rogue
+1 Clockwork Hydra
+1 Whirlermaker
+1 Gearsmith Prodigy
+1 Aviation Pioneer
+1 Pilgrim's Eye
+1 Gearseeker Serpent
+1 Aether Spellbomb
+1 Artificer's Epiphany
+1 Thriving Isle
+1 Seat of the Synod
+6 Island
+

--- a/library/Jumpstart 2022/Inventive-(4).txt
+++ b/library/Jumpstart 2022/Inventive-(4).txt
@@ -1,0 +1,17 @@
+1 Solemn Simulacrum
+1 Launch Mishap
+1 Whirler Rogue
+1 Cogwork Assembler
+1 Mishra's Factory
+1 Dutiful Replicator
+1 Gearsmith Prodigy
+1 Aviation Pioneer
+1 Assembly-Worker
+1 Self-Assembler
+1 Gearseeker Serpent
+1 Aether Spellbomb
+1 Artificer's Epiphany
+1 Thriving Isle
+1 Seat of the Synod
+5 Island
+

--- a/library/Jumpstart 2022/Knights.txt
+++ b/library/Jumpstart 2022/Knights.txt
@@ -1,0 +1,15 @@
+1 The Circle of Loyalty
+1 Balan, Wandering Knight
+1 Danitha Capashen, Paragon
+1 Kwende, Pride of Femeref
+1 Syr Alin, the Lion's Claw
+1 Hero's Blade
+1 Chains of Custody
+1 Order of the Golden Cricket
+1 Shining Armor
+1 Jousting Lance
+1 Benalish Honor Guard
+1 Skyhunter Prowler
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Landfall-(1).txt
+++ b/library/Jumpstart 2022/Landfall-(1).txt
@@ -1,0 +1,16 @@
+1 Rampaging Baloths
+1 Courser of Kruphix
+1 Turntimber Basilisk
+1 Primeval Herald
+1 Zendikar's Roil
+1 Rampaging Growth
+1 Oashra Cultivator
+1 Snapping Gnarlid
+1 Adventuring Gear
+1 Canopy Baloth
+1 Khalni Heart Expedition
+1 Master's Rebuke
+1 Evolving Wilds
+1 Thriving Grove
+6 Forest
+

--- a/library/Jumpstart 2022/Landfall-(2).txt
+++ b/library/Jumpstart 2022/Landfall-(2).txt
@@ -1,0 +1,16 @@
+1 Avenger of Zendikar
+1 Turntimber Basilisk
+1 Primeval Herald
+1 Baloth Woodcrasher
+1 Rampaging Growth
+1 Oashra Cultivator
+1 Snapping Gnarlid
+1 Fertilid
+1 Canopy Baloth
+1 Groundswell
+1 Khalni Heart Expedition
+1 Broken Bond
+1 Evolving Wilds
+1 Thriving Grove
+6 Forest
+

--- a/library/Jumpstart 2022/Law-(1).txt
+++ b/library/Jumpstart 2022/Law-(1).txt
@@ -1,0 +1,15 @@
+1 Archon of Justice
+1 Magnanimous Magistrate
+1 Arrest
+1 Righteousness
+1 Valorous Stance
+1 Gideon's Lawkeeper
+1 Ninth Bridge Patrol
+1 Kami of Ancient Law
+1 Midnight Guard
+1 Nightguard Patrol
+1 Skyhunter Patrol
+1 Divine Verdict
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Law-(2).txt
+++ b/library/Jumpstart 2022/Law-(2).txt
@@ -1,0 +1,15 @@
+1 Decree of Justice
+1 Magnanimous Magistrate
+1 Arrest
+1 Phalanx Tactics
+1 Unquestioned Authority
+1 Law-Rune Enforcer
+1 Ninth Bridge Patrol
+1 Kami of Ancient Law
+1 Midnight Guard
+1 Nightguard Patrol
+1 Skyhunter Patrol
+1 Radiant's Judgment
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Law-(3).txt
+++ b/library/Jumpstart 2022/Law-(3).txt
@@ -1,0 +1,15 @@
+1 Gideon, Champion of Justice
+1 Magnanimous Magistrate
+1 Arrest
+1 Righteousness
+1 Unquestioned Authority
+1 Gideon's Lawkeeper
+1 Ninth Bridge Patrol
+1 Kami of Ancient Law
+1 Midnight Guard
+1 Nightguard Patrol
+1 Skyhunter Patrol
+1 Angelic Edict
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Law-(4).txt
+++ b/library/Jumpstart 2022/Law-(4).txt
@@ -1,0 +1,15 @@
+1 Isamaru, Hound of Konda
+1 Michiko Konda, Truth Seeker
+1 Magnanimous Magistrate
+1 Arrest
+1 Murder Investigation
+1 Edifice of Authority
+1 Ninth Bridge Patrol
+1 Kami of Ancient Law
+1 Midnight Guard
+1 Nightguard Patrol
+1 Skyhunter Patrol
+1 Bring to Trial
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Merfolk-(1).txt
+++ b/library/Jumpstart 2022/Merfolk-(1).txt
@@ -1,0 +1,15 @@
+1 Seafloor Oracle
+1 Merrow Reejerey
+1 River Sneak
+1 Sage of the Falls
+1 Aquatic Incursion
+1 Soul Read
+1 Triton Shorestalker
+1 Shaper Apprentice
+1 Watertrap Weaver
+1 Storm Sculptor
+1 One With the Wind
+1 Crashing Tide
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Merfolk-(2).txt
+++ b/library/Jumpstart 2022/Merfolk-(2).txt
@@ -1,0 +1,15 @@
+1 Svyelun of Sea and Sky
+1 Synchronized Eviction
+1 Merrow Reejerey
+1 River Sneak
+1 Windrider Patrol
+1 Merfolk Pupil
+1 Soul Read
+1 Triton Shorestalker
+1 Watertrap Weaver
+1 Saltwater Stalwart
+1 One With the Wind
+1 Crashing Tide
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Merfolk-(3).txt
+++ b/library/Jumpstart 2022/Merfolk-(3).txt
@@ -1,0 +1,15 @@
+1 Harbinger of the Tides
+1 Wake Thrasher
+1 Synchronized Eviction
+1 Merrow Reejerey
+1 Fallowsage
+1 Windrider Patrol
+1 Soul Read
+1 Triton Shorestalker
+1 Stonybrook Angler
+1 Watertrap Weaver
+1 One With the Wind
+1 Crashing Tide
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Merfolk-(4).txt
+++ b/library/Jumpstart 2022/Merfolk-(4).txt
@@ -1,0 +1,15 @@
+1 Merfolk Sovereign
+1 Merrow Reejerey
+1 River Sneak
+1 Windrider Patrol
+1 Aquatic Incursion
+1 Soul Read
+1 Triton Shorestalker
+1 Watertrap Weaver
+1 Library Larcenist
+1 Saltwater Stalwart
+1 One With the Wind
+1 Crashing Tide
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Morbid-(1).txt
+++ b/library/Jumpstart 2022/Morbid-(1).txt
@@ -1,0 +1,16 @@
+1 Reaper from the Abyss
+1 Disciple of Perdition
+1 Morkrut Banshee
+1 Spawning Pit
+1 Bone Picker
+1 Suspicious Shambler
+1 Tragic Slip
+1 Wakedancer
+1 Liliana's Steward
+1 Durable Coilbug
+1 Village Rites
+1 Reave Soul
+1 Mortuary Mire
+1 Thriving Moor
+6 Swamp
+

--- a/library/Jumpstart 2022/Morbid-(2).txt
+++ b/library/Jumpstart 2022/Morbid-(2).txt
@@ -1,0 +1,16 @@
+1 Priest of the Blood Rite
+1 Skirsdag High Priest
+1 Morkrut Banshee
+1 Reassembling Skeleton
+1 Bone Picker
+1 Vampiric Rites
+1 Suspicious Shambler
+1 Wakedancer
+1 Tragic Slip
+1 Liliana's Steward
+1 Village Rites
+1 Reave Soul
+1 Mortuary Mire
+1 Thriving Moor
+6 Swamp
+

--- a/library/Jumpstart 2022/Multi-Headed-(1).txt
+++ b/library/Jumpstart 2022/Multi-Headed-(1).txt
@@ -1,0 +1,15 @@
+1 Benevolent Hydra
+1 Domesticated Hydra
+1 Clockwork Hydra
+1 Feral Hydra
+1 Hydra's Growth
+1 Servant of the Scale
+1 Ilysian Caryatid
+1 Fertilid
+1 Adventurous Impulse
+1 Scale the Heights
+1 Hunter's Edge
+1 Soul's Might
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Multi-Headed-(2).txt
+++ b/library/Jumpstart 2022/Multi-Headed-(2).txt
@@ -1,0 +1,15 @@
+1 Primordial Hydra
+1 Benevolent Hydra
+1 Domesticated Hydra
+1 Clockwork Hydra
+1 Ordeal of Nylea
+1 Hydra's Growth
+1 Servant of the Scale
+1 Kujar Seedsculptor
+1 Ilysian Caryatid
+1 Pridemalkin
+1 Titanic Brawl
+1 Hunter's Edge
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Primates.txt
+++ b/library/Jumpstart 2022/Primates.txt
@@ -1,0 +1,16 @@
+1 Kibo, Uktabi Prince
+1 Monkey Cage
+1 Uktabi Orangutan
+1 Towering Gibbon
+1 Declare Dominance
+1 Treetop Village
+1 Wily Bandar
+1 Scrounging Bandar
+1 Silverback Shaman
+1 Hooting Mandrills
+1 Ram Through
+1 Cultivate
+1 Simian Brawler
+1 Thriving Grove
+6 Forest
+

--- a/library/Jumpstart 2022/Raid-(1).txt
+++ b/library/Jumpstart 2022/Raid-(1).txt
@@ -1,0 +1,15 @@
+1 Kari Zev, Skyship Raider
+1 Rigging Runner
+1 War-Name Aspirant
+1 Goblin Oriflamme
+1 Daring Piracy
+1 Lavastep Raider
+1 Swaggering Corsair
+1 Keldon Raider
+1 Storm Fleet Pyromancer
+1 Plundering Predator
+1 Raze the Effigy
+1 Firecannon Blast
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Raid-(2).txt
+++ b/library/Jumpstart 2022/Raid-(2).txt
@@ -1,0 +1,15 @@
+1 Glint-Horn Buccaneer
+1 Bag of Holding
+1 Rigging Runner
+1 War-Name Aspirant
+1 Lightning Axe
+1 Daring Piracy
+1 Immersturm Raider
+1 Swaggering Corsair
+1 Storm Fleet Pyromancer
+1 Plundering Predator
+1 Keldon Raider
+1 Firecannon Blast
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Raid-(3).txt
+++ b/library/Jumpstart 2022/Raid-(3).txt
@@ -1,0 +1,15 @@
+1 Brazen Cannonade
+1 Rigging Runner
+1 War-Name Aspirant
+1 Mardu Heart-Piercer
+1 Daring Piracy
+1 Axgard Cavalry
+1 Swaggering Corsair
+1 Keldon Raider
+1 Storm Fleet Pyromancer
+1 Plundering Predator
+1 Fervent Strike
+1 Firecannon Blast
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Raid-(4).txt
+++ b/library/Jumpstart 2022/Raid-(4).txt
@@ -1,0 +1,15 @@
+1 Brazen Cannonade
+1 Rigging Runner
+1 War-Name Aspirant
+1 Ordeal of Purphoros
+1 Daring Piracy
+1 Borderland Marauder
+1 Swaggering Corsair
+1 Brazen Wolves
+1 Keldon Raider
+1 Storm Fleet Pyromancer
+1 Plundering Predator
+1 Firecannon Blast
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Rats.txt
+++ b/library/Jumpstart 2022/Rats.txt
@@ -1,0 +1,15 @@
+1 Ashcoat of the Shadow Swarm
+1 Ogre Slumlord
+1 Nezumi Bone-Reader
+1 Crypt Rats
+1 Infiltration Lens
+1 Ulcerate
+1 Ossuary Rats
+1 Typhoid Rats
+1 Burglar Rat
+1 Sinuous Vermin
+1 Chittering Rats
+1 Eviscerate
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Scrying-(1).txt
+++ b/library/Jumpstart 2022/Scrying-(1).txt
@@ -1,0 +1,15 @@
+1 Kenessos, Priest of Thassa
+1 Biblioplex Kraken
+1 Cryptic Serpent
+1 Perilous Voyage
+1 Interpret the Signs
+1 Preordain
+1 Faerie Seer
+1 Sage's Row Savant
+1 Moonfolk Puzzlemaker
+1 Octoprophet
+1 No Escape
+1 Raiders' Karve
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Scrying-(2).txt
+++ b/library/Jumpstart 2022/Scrying-(2).txt
@@ -1,0 +1,15 @@
+1 Djinn of Wishes
+1 Kenessos, Priest of Thassa
+1 Biblioplex Kraken
+1 Cryptic Serpent
+1 Anchor to the Aether
+1 Condescend
+1 Faerie Seer
+1 Preordain
+1 Augury Owl
+1 Moonfolk Puzzlemaker
+1 Octoprophet
+1 Explorer's Scope
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Shapeshifters.txt
+++ b/library/Jumpstart 2022/Shapeshifters.txt
@@ -1,0 +1,15 @@
+1 Pirated Copy
+1 Gigantoplasm
+1 Mirror Image
+1 Bloodline Pretender
+1 Lookout's Dispersal
+1 Heirloom Blade
+1 Universal Automaton
+1 Amoeboid Changeling
+1 Mistwalker
+1 Littjara Kinseekers
+1 Chilling Trap
+1 Crashing Tide
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Snow.txt
+++ b/library/Jumpstart 2022/Snow.txt
@@ -1,0 +1,15 @@
+1 Isu the Abominable
+1 Marit Lage's Slumber
+1 Coldsteel Heart
+1 Avalanche Caller
+1 Phyrexian Ironfoot
+1 Icebind Pillar
+1 Pilfering Hawk
+1 Frostpeak Yeti
+1 Chillerpillar
+1 Berg Strider
+1 Winter's Rest
+1 Crippling Chill
+1 Shimmerdrift Vale
+7 Snow-Covered Island
+

--- a/library/Jumpstart 2022/Speedy.txt
+++ b/library/Jumpstart 2022/Speedy.txt
@@ -1,0 +1,15 @@
+1 Kiki-Jiki, Mirror Breaker
+1 Ardoz, Cobbler of War
+1 Bolt Hound
+1 Warcry Phoenix
+1 Markov Warlord
+1 Fiery Conclusion
+1 Fanatical Firebrand
+1 Nest Robber
+1 Mudbutton Torchrunner
+1 Irreverent Revelers
+1 Rush of Adrenaline
+1 Swift Kick
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Spicy.txt
+++ b/library/Jumpstart 2022/Spicy.txt
@@ -1,0 +1,15 @@
+1 Auntie Blyte, Bad Influence
+1 Loxodon Warhammer
+1 Impending Doom
+1 Goblin Artillery
+1 Goblin Psychopath
+1 Ravenous Giant
+1 Spear Spewer
+1 Fireslinger
+1 Smoldering Efreet
+1 Coalhauler Swine
+1 Aftershock
+1 Sarkhan's Rage
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Spirits-(1).txt
+++ b/library/Jumpstart 2022/Spirits-(1).txt
@@ -1,0 +1,15 @@
+1 Angel of Flight Alabaster
+1 Selfless Spirit
+1 Eidolon of Rhetoric
+1 Mausoleum Guard
+1 Gallows Warden
+1 Not Forgotten
+1 Chains of Custody
+1 Doomed Traveler
+1 Pilgrim of the Ages
+1 Apothecary Geist
+1 Blessed Defiance
+1 Divine Verdict
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Spirits-(2).txt
+++ b/library/Jumpstart 2022/Spirits-(2).txt
@@ -1,0 +1,15 @@
+1 Hour of Reckoning
+1 Eidolon of Rhetoric
+1 Mausoleum Guard
+1 Gallows Warden
+1 Devouring Light
+1 Chains of Custody
+1 Doomed Traveler
+1 Kami of Ancient Law
+1 Pilgrim of the Ages
+1 Martyr's Soul
+1 Blessed Defiance
+1 Triplicate Spirits
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Teamwork-(1).txt
+++ b/library/Jumpstart 2022/Teamwork-(1).txt
@@ -1,0 +1,16 @@
+1 Agrus Kos, Eternal Soldier
+1 Taranika, Akroan Veteran
+1 Angelic Cub
+1 Valorous Stance
+1 Angelic Protector
+1 Dragon Blood
+1 Task Force
+1 Infantry Veteran
+1 Cavalry Drillmaster
+1 Combat Professor
+1 Moment of Triumph
+1 Cage of Hands
+1 Sandstone Bridge
+1 Thriving Heath
+6 Plains
+

--- a/library/Jumpstart 2022/Teamwork-(2).txt
+++ b/library/Jumpstart 2022/Teamwork-(2).txt
@@ -1,0 +1,16 @@
+1 Agrus Kos, Eternal Soldier
+1 Angelic Cub
+1 Valorous Stance
+1 Tempered Veteran
+1 Angelic Protector
+1 Task Force
+1 Infantry Veteran
+1 Cavalry Drillmaster
+1 Iron Bully
+1 Combat Professor
+1 Light of Hope
+1 Weapon Rack
+1 Sandstone Bridge
+1 Thriving Heath
+6 Plains
+

--- a/library/Jumpstart 2022/Think-Again (1).txt
+++ b/library/Jumpstart 2022/Think-Again (1).txt
@@ -1,0 +1,16 @@
+1 Jace, Arcane Strategist
+1 Spectral Sailor
+1 Faerie Vandal
+1 Serum Visions
+1 Memorial to Genius
+1 Soul Read
+1 Merfolk Pupil
+1 Eyekite
+1 Mystic Skyfish
+1 Teferi's Protege
+1 Tome Anima
+1 Steelgaze Griffin
+1 Drag Under
+1 Thriving Isle
+6 Island
+

--- a/library/Jumpstart 2022/Think-Again (2).txt
+++ b/library/Jumpstart 2022/Think-Again (2).txt
@@ -1,0 +1,15 @@
+1 Alandra, Sky Dreamer
+1 Spectral Sailor
+1 Faerie Vandal
+1 Hedron Archive
+1 Eternity Snare
+1 Soul Read
+1 Merfolk Pupil
+1 Mystic Skyfish
+1 Teferi's Protege
+1 Tome Anima
+1 Steelgaze Griffin
+1 Opt
+1 Thriving Isle
+7 Island
+

--- a/library/Jumpstart 2022/Think-Again (3).txt
+++ b/library/Jumpstart 2022/Think-Again (3).txt
@@ -1,0 +1,16 @@
+1 Alandra, Sky Dreamer
+1 Spectral Sailor
+1 Faerie Vandal
+1 Neutralize
+1 Lay Claim
+1 Merfolk Pupil
+1 Mystic Skyfish
+1 Teferi's Protege
+1 Tome Anima
+1 Steelgaze Griffin
+1 Startling Development
+1 Hieroglyphic Illumination
+1 Thriving Isle
+1 Desert of the Mindful
+6 Island
+

--- a/library/Jumpstart 2022/Think-Again (4).txt
+++ b/library/Jumpstart 2022/Think-Again (4).txt
@@ -1,0 +1,16 @@
+1 Faerie Formation
+1 Spectral Sailor
+1 Faerie Vandal
+1 Military Intelligence
+1 Memorial to Genius
+1 Soul Read
+1 Merfolk Pupil
+1 Mystic Skyfish
+1 Teferi's Protege
+1 Tome Anima
+1 Steelgaze Griffin
+1 Mantle of Tides
+1 Leave in the Dust
+1 Thriving Isle
+6 Island
+

--- a/library/Jumpstart 2022/Treasure-(1).txt
+++ b/library/Jumpstart 2022/Treasure-(1).txt
@@ -1,0 +1,15 @@
+1 Captain Lannery Storm
+1 Sokenzan Smelter
+1 Blood Aspirant
+1 Rapacious Dragon
+1 Trove of Temptation
+1 Goldhound
+1 Dutiful Replicator
+1 Brazen Freebooter
+1 Ripscale Predator
+1 Sudden Breakthrough
+1 Goldvein Pick
+1 Welding Sparks
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Treasure-(2).txt
+++ b/library/Jumpstart 2022/Treasure-(2).txt
@@ -1,0 +1,15 @@
+1 Professional Face-Breaker
+1 Blood Aspirant
+1 Pyre-Sledge Arsonist
+1 Rapacious Dragon
+1 Barrage Ogre
+1 Goldhound
+1 Reckless Fireweaver
+1 Dutiful Replicator
+1 Brazen Freebooter
+1 Goldvein Pick
+1 Improvised Weaponry
+1 Welding Sparks
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Treasure-(3).txt
+++ b/library/Jumpstart 2022/Treasure-(3).txt
@@ -1,0 +1,15 @@
+1 Goldspan Dragon
+1 Blood Aspirant
+1 Rapacious Dragon
+1 Kuldotha Flamefiend
+1 Blaze
+1 Goldhound
+1 Vault Robber
+1 Dutiful Replicator
+1 Brazen Freebooter
+1 Goldvein Pick
+1 Welding Sparks
+1 Big Score
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Treasure-(4).txt
+++ b/library/Jumpstart 2022/Treasure-(4).txt
@@ -1,0 +1,15 @@
+1 Gadrak, the Crown-Scourge
+1 Blood Aspirant
+1 Rapacious Dragon
+1 Kuldotha Flamefiend
+1 Trove of Temptation
+1 Goldhound
+1 Gleaming Barrier
+1 Dutiful Replicator
+1 Brazen Freebooter
+1 Goldvein Pick
+1 Welding Sparks
+1 Improvised Weaponry
+1 Thriving Bluff
+7 Mountain
+

--- a/library/Jumpstart 2022/Unlucky-Thirteen.txt
+++ b/library/Jumpstart 2022/Unlucky-Thirteen.txt
@@ -1,0 +1,16 @@
+1 Tree of Perdition
+1 Triskaidekaphobia
+1 Disciple of Perdition
+1 Sling-Gang Lieutenant
+1 Ruthless Disposal
+1 Exsanguinate
+1 Blight Keeper
+1 Gnawing Zombie
+1 Skirsdag Supplicant
+1 Soulcage Fiend
+1 Dread Rider
+1 Tragic Slip
+1 Piranha Marsh
+1 Thriving Moor
+6 Swamp
+

--- a/library/Jumpstart 2022/Urza's.txt
+++ b/library/Jumpstart 2022/Urza's.txt
@@ -1,0 +1,17 @@
+1 Karn Liberated
+1 Walking Ballista
+1 Golem Artisan
+1 Meteor Golem
+1 Planar Atlas
+1 Urza's Factory
+1 Locthwain Gargoyle
+1 Runed Servitor
+1 Manakin
+1 Thaumaturge's Familiar
+1 Universal Solvent
+1 Alchemist's Vial
+1 Expedition Map
+3 Urza's Tower
+2 Urza's Power Plant
+2 Urza's Mine
+

--- a/library/Jumpstart 2022/Vehicles.txt
+++ b/library/Jumpstart 2022/Vehicles.txt
@@ -1,0 +1,15 @@
+1 Lita, Mechanical Engineer
+1 Peacewalker Colossus
+1 Hotshot Mechanic
+1 Imperial Recovery Unit
+1 Aethershield Artificer
+1 Aerial Modification
+1 Kitsune Ace
+1 Sanctum Gargoyle
+1 Built to Last
+1 Caught in the Brights
+1 Giant Ox
+1 Aradara Express
+1 Thriving Heath
+7 Plains
+

--- a/library/Jumpstart 2022/Wolves-(1).txt
+++ b/library/Jumpstart 2022/Wolves-(1).txt
@@ -1,0 +1,15 @@
+1 Wicked Wolf
+1 Mild-Mannered Librarian
+1 Packsong Pup
+1 Wolfwillow Haven
+1 Arlinn, Voice of the Pack
+1 Ferocious Pup
+1 Bounding Wolf
+1 Fierce Witchstalker
+1 Spectral Hunt-Caller
+1 Wolf's Quarry
+1 Prey Upon
+1 Wolfkin Bond
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Wolves-(2).txt
+++ b/library/Jumpstart 2022/Wolves-(2).txt
@@ -1,0 +1,15 @@
+1 Master of the Wild Hunt
+1 Mild-Mannered Librarian
+1 Howlgeist
+1 Moonlight Hunt
+1 Arlinn, Voice of the Pack
+1 Young Wolf
+1 Pestilent Wolf
+1 Bounding Wolf
+1 Ferocious Pup
+1 Spectral Hunt-Caller
+1 Prey Upon
+1 Howl of the Hunt
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Wolves-(3).txt
+++ b/library/Jumpstart 2022/Wolves-(3).txt
@@ -1,0 +1,15 @@
+1 Kessig Cagebreakers
+1 Feed the Pack
+1 Mild-Mannered Librarian
+1 Predator's Howl
+1 Wolfwillow Haven
+1 Arlinn, Voice of the Pack
+1 Sporeback Wolf
+1 Ferocious Pup
+1 Bounding Wolf
+1 Spectral Hunt-Caller
+1 Prey Upon
+1 Hunger of the Howlpack
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Wolves-(4).txt
+++ b/library/Jumpstart 2022/Wolves-(4).txt
@@ -1,0 +1,15 @@
+1 Nightpack Ambusher
+1 Mild-Mannered Librarian
+1 Briarpack Alpha
+1 Wolfwillow Haven
+1 Arlinn, Voice of the Pack
+1 Pestilent Wolf
+1 Ferocious Pup
+1 Bounding Wolf
+1 Spectral Hunt-Caller
+1 Flourishing Hunter
+1 Prey Upon
+1 Howl of the Hunt
+1 Thriving Grove
+7 Forest
+

--- a/library/Jumpstart 2022/Zombies-(1).txt
+++ b/library/Jumpstart 2022/Zombies-(1).txt
@@ -1,0 +1,15 @@
+1 Gravecrawler
+1 Necromancer's Stockpile
+1 Deadly Plot
+1 Lord of the Accursed
+1 Mire Triton
+1 Gravedigger
+1 Suspicious Shambler
+1 Crow of Dark Tidings
+1 Karfell Kennel-Master
+1 Maalfeld Twins
+1 Dead Weight
+1 Cemetery Recruitment
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Zombies-(2).txt
+++ b/library/Jumpstart 2022/Zombies-(2).txt
@@ -1,0 +1,15 @@
+1 Liliana, Death's Majesty
+1 Deadly Plot
+1 Lord of the Accursed
+1 Stitcher’s Supplier
+1 Gravedigger
+1 Suspicious Shambler
+1 Returned Reveler
+1 Crow of Dark Tidings
+1 Ghoulraiser
+1 Maalfeld Twins
+1 Dead Weight
+1 Cemetery Recruitment
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Zombies-(3).txt
+++ b/library/Jumpstart 2022/Zombies-(3).txt
@@ -1,0 +1,15 @@
+1 Endless Ranks of the Dead
+1 Deadly Plot
+1 Lord of the Accursed
+1 Mire Triton
+1 Graf Harvest
+1 Suspicious Shambler
+1 Gnawing Zombie
+1 Crow of Dark Tidings
+1 Gavony Unhallowed
+1 Maalfeld Twins
+1 Dead Weight
+1 Cemetery Recruitment
+1 Thriving Moor
+7 Swamp
+

--- a/library/Jumpstart 2022/Zombies-(4).txt
+++ b/library/Jumpstart 2022/Zombies-(4).txt
@@ -1,0 +1,15 @@
+1 Liliana's Mastery
+1 Deadly Plot
+1 Lord of the Accursed
+1 Undead Augur
+1 Cellar Door
+1 Suspicious Shambler
+1 Shambling Ghoul
+1 Crow of Dark Tidings
+1 Marauding Boneslasher
+1 Maalfeld Twins
+1 Dead Weight
+1 Cemetery Recruitment
+1 Thriving Moor
+7 Swamp
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Cunning-1.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Cunning-1.txt
@@ -1,0 +1,14 @@
+1 Rare or mythic rare
+1 Minas Tirith Garrison
+1 Pelargir Survivor
+1 Captain of Umbar
+1 Knights of Dol Amroth
+1 Bewitching Leechcraft
+1 Glorious Gale
+1 Arwen's Gift
+1 Ioreth of the Healing House
+1 Meneldor, Swift Savior
+1 Horses of the Bruinen
+1 The Bath Song
+8 Island
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Cunning-2.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Cunning-2.txt
@@ -1,0 +1,14 @@
+1 Rare or mythic rare
+1 Minas Tirith Garrison
+1 Pelargir Survivor
+1 Captain of Umbar
+1 Knights of Dol Amroth
+1 Bewitching Leechcraft
+1 Isolation at Orthanc
+1 Lórien Revealed
+1 Bill Ferny, Bree Swindler
+1 Elrond, Lord of Rivendell
+1 Horses of the Bruinen
+1 Mirror of Galadriel
+8 Island
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Elven-1.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Elven-1.txt
@@ -1,0 +1,14 @@
+1 Rare or mythic rare
+1 Mirkwood Channeler
+1 Lothlórien Lookout
+1 Chance-Met Elves
+1 Galadhrim Guide
+1 Enraged Huorn
+1 Shower of Arrows
+1 Glorfindel, Dauntless Rescuer
+1 Celeborn the Wise
+1 Stew the Coneys
+1 Entish Restoration
+1 Lembas
+8 Forest
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Elven-2.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Elven-2.txt
@@ -1,0 +1,14 @@
+1 Rare or mythic rare
+1 Mirkwood Channeler
+1 Mirkwood Spider
+1 Lothlórien Lookout
+1 Chance-Met Elves
+1 Galadhrim Guide
+1 Bombadil's Song
+1 Revive the Shire
+1 Celeborn the Wise
+1 Quickbeam, Upstart Ent
+1 Stew the Coneys
+1 Ent-Draught Basin
+8 Forest
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Mortals-1.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Mortals-1.txt
@@ -1,0 +1,14 @@
+1 Rare or mythic rare
+1 Eagle of Deliverance
+1 Took Reaper
+1 Eastfarthing Farmer
+1 Soldier of the Grey Host
+1 Second Breakfast
+1 Fog on the Barrow-Downs
+1 Banish from Edoras
+1 Shire Shirriff
+1 Éowyn, Lady of Rohan
+1 Faramir, Field Commander
+1 Barrow-Blade
+8 Plains
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Mortals-2.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Mortals-2.txt
@@ -1,0 +1,14 @@
+1 Rare or mythic rare
+1 Eagle of Deliverance
+1 East-Mark Cavalier
+1 Took Reaper
+1 Errand-Rider of Gondor
+1 Slip On the Ring
+1 Banish from Edoras
+1 Samwise the Stouthearted
+1 Faramir, Field Commander
+1 Landroval, Horizon Witness
+1 Reprieve
+1 Inherited Envelope
+8 Plains
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Orcish-1.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Orcish-1.txt
@@ -1,0 +1,14 @@
+1 Rare or mythic rare
+1 Warg Rider
+1 Easterling Vanguard
+1 Mordor Muster
+1 Dunland Crebain
+1 Mirkwood Bats
+1 Sam's Desperate Rescue
+1 Orcish Medicine
+1 Gorbag of Minas Morgul
+1 Gothmog, Morgul Lieutenant
+1 Grond, the Gatebreaker
+1 Bitter Downfall
+8 Swamp
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Orcish-2.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Orcish-2.txt
@@ -1,0 +1,14 @@
+1 Rare or mythic rare
+1 Warg Rider
+1 Easterling Vanguard
+1 Mordor Muster
+1 Dunland Crebain
+1 Mordor Trebuchet
+1 Lash of the Balrog
+1 Nasty End
+1 Gorbag of Minas Morgul
+1 Gothmog, Morgul Lieutenant
+1 Voracious Fell Beast
+1 March from the Black Gate
+8 Swamp
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Riders-1.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Riders-1.txt
@@ -1,0 +1,14 @@
+1 Rare or mythic rare
+1 Riders of the Mark
+1 Rohirrim Lancer
+1 Rally at the Hornburg
+1 Relentless Rohirrim
+1 Gimli's Fury
+1 Smite the Deathless
+1 Quarrel's End
+1 Erkenbrand, Lord of Westfold
+1 Éomer of the Riddermark
+1 Rising of the Day
+1 Fear, Fire, Foes!
+8 Mountain
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Riders-2.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart Volume 2/Riders-2.txt
@@ -1,0 +1,14 @@
+1 Rare or mythic rare
+1 Riders of the Mark
+1 Rohirrim Lancer
+1 Rally at the Hornburg
+1 Haradrim Spearmaster
+1 Relentless Rohirrim
+1 Smite the Deathless
+1 Gimli's Axe
+1 Erkenbrand, Lord of Westfold
+1 Éomer of the Riddermark
+1 Fear, Fire, Foes!
+1 Book of Mazarbul
+8 Mountain
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Courageous-1.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Courageous-1.txt
@@ -1,0 +1,14 @@
+1 Saradoc, Master of Buckland
+1 Rare or mythic rare
+1 Esquire of the King
+1 Samwise the Stouthearted
+1 Took Reaper
+1 Rosie Cotton of South Lane
+1 Errand-Rider of Gondor
+1 Bill the Pony
+1 Lost to Legend
+1 Fog on the Barrow-Downs
+1 Slip On the Ring
+1 Escape from Orthanc
+8 Plains
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Courageous-2.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Courageous-2.txt
@@ -1,0 +1,14 @@
+1 Saradoc, Master of Buckland
+1 Rare or mythic rare
+1 Nimble Hobbit
+1 Samwise the Stouthearted
+1 Took Reaper
+1 Rosie Cotton of South Lane
+1 Eastfarthing Farmer
+1 Bill the Pony
+1 Reprieve
+1 Hobbit's Sting
+1 Slip On the Ring
+1 Escape from Orthanc
+8 Plains
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Journey-1.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Journey-1.txt
@@ -1,0 +1,14 @@
+1 Elanor Gardner
+1 Rare or mythic rare
+1 Mirkwood Spider
+1 Meriadoc Brandybuck
+1 Brandywine Farmer
+1 Mirrormere Guardian
+1 Dúnedain Rangers
+1 Quickbeam, Upstart Ent
+1 Ent's Fury
+1 Gift of Strands
+1 Bombadil's Song
+1 Revive the Shire
+8 Forest
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Journey-2.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Journey-2.txt
@@ -1,0 +1,14 @@
+1 Elanor Gardner
+1 Rare or mythic rare
+1 Wose Pathfinder
+1 Meriadoc Brandybuck
+1 Brandywine Farmer
+1 Peregrin Took
+1 Enraged Huorn
+1 Quickbeam, Upstart Ent
+1 Stew the Coneys
+1 Galadhrim Bow
+1 Pippin's Bravery
+1 Revive the Shire
+8 Forest
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Marauders-1.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Marauders-1.txt
@@ -1,0 +1,14 @@
+1 Assault on Osgiliath
+1 Rare or mythic rare
+1 Erebor Flamesmith
+1 Battle-Scarred Goblin
+1 Swarming of Moria
+1 Grishnákh, Brash Instigator
+1 Gimli, Counter of Kills
+1 Olog-hai Crusher
+1 Foray of Orcs
+1 Fear, Fire, Foes!
+1 Gimli's Fury
+1 Quarrel's End
+8 Mountain
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Marauders-2.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Marauders-2.txt
@@ -1,0 +1,14 @@
+1 Assault on Osgiliath
+1 Rare or mythic rare
+1 Erebor Flamesmith
+1 Goblin Fireleaper
+1 Swarming of Moria
+1 Grishnákh, Brash Instigator
+1 Gimli, Counter of Kills
+1 Olog-hai Crusher
+1 Foray of Orcs
+1 Smite the Deathless
+1 Rush the Room
+1 Quarrel's End
+8 Mountain
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Mordor-1.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Mordor-1.txt
@@ -1,0 +1,14 @@
+1 Ringwraiths
+1 Rare or mythic rare
+1 Mordor Muster
+1 Gollum, Patient Plotter
+1 Uruk-hai Berserker
+1 Nazgûl
+1 Gothmog, Morgul Lieutenant
+1 Cirith Ungol Patrol
+1 Claim the Precious
+1 Gollum's Bite
+1 Nasty End
+1 Shelob's Ambush
+8 Swamp
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Mordor-2.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Mordor-2.txt
@@ -1,0 +1,14 @@
+1 Ringwraiths
+1 Rare or mythic rare
+1 Mordor Muster
+1 Gollum, Patient Plotter
+1 Dunland Crebain
+1 Gríma Wormtongue
+1 Gothmog, Morgul Lieutenant
+1 Cirith Ungol Patrol
+1 Lash of the Balrog
+1 Bitter Downfall
+1 Nasty End
+1 Orcish Medicine
+8 Swamp
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Tricksy-1.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Tricksy-1.txt
@@ -1,0 +1,14 @@
+1 Elvish Mariner
+1 Rare or mythic rare
+1 Glorious Gale
+1 Arwen's Gift
+1 Horses of the Bruinen
+1 Council's Deliberation
+1 Nimrodel Watcher
+1 Pelargir Survivor
+1 Captain of Umbar
+1 Elrond, Lord of Rivendell
+1 Meneldor, Swift Savior
+1 Willow-Wind
+8 Island
+

--- a/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Tricksy-2.txt
+++ b/library/Lord of the Rings: Tales of Middle-Earth Jumpstart/Tricksy-2.txt
@@ -1,0 +1,14 @@
+1 Elvish Mariner
+1 Rare or mythic rare
+1 Nimrodel Watcher
+1 Pelargir Survivor
+1 Ithilien Kingfisher
+1 Elrond, Lord of Rivendell
+1 Saruman the White
+1 Willow-Wind
+1 Glorious Gale
+1 Arwen's Gift
+1 Horses of the Bruinen
+1 Saruman's Trickery
+8 Island
+

--- a/library/March of the Machine Jumpstart/Brood-1.txt
+++ b/library/March of the Machine Jumpstart/Brood-1.txt
@@ -1,0 +1,14 @@
+1 Essence of Orthodoxy
+1 Random rare or mythic rare
+1 Norn's Inquisitor
+1 Phyrexian Pegasus
+1 Sunder the Gateway
+1 Alabaster Host Sanctifier
+1 Infected Defector
+1 Alabaster Host Intercessor
+1 Angelic Intervention
+1 Cut Short
+1 Seedpod Caretaker
+1 Tiller of Flesh
+8 Plains
+

--- a/library/March of the Machine Jumpstart/Brood-2.txt
+++ b/library/March of the Machine Jumpstart/Brood-2.txt
@@ -1,0 +1,14 @@
+1 Essence of Orthodoxy
+1 Random rare or mythic rare
+1 Phyrexian Pegasus
+1 Alabaster Host Sanctifier
+1 Infected Defector
+1 Alabaster Host Intercessor
+1 Aerial Boost
+1 Inspired Charge
+1 Norn's Inquisitor
+1 Seedpod Caretaker
+1 Tiller of Flesh
+1 Seal from Existence
+8 Plains
+

--- a/library/March of the Machine Jumpstart/Buff-1.txt
+++ b/library/March of the Machine Jumpstart/Buff-1.txt
@@ -1,0 +1,14 @@
+1 Random rare or mythic rare
+1 Fairgrounds Trumpeter
+1 Placid Rottentail
+1 Wary Thespian
+1 Converter Beast
+1 Timberland Ancient
+1 Arachnoid Adaptation
+1 Cosmic Hunger
+1 Fertilid's Favor
+1 Ruins Recluse
+1 Kami of Whispered Hopes
+1 Surrak and Goreclaw
+8 Forest
+

--- a/library/March of the Machine Jumpstart/Buff-2.txt
+++ b/library/March of the Machine Jumpstart/Buff-2.txt
@@ -1,0 +1,13 @@
+1 Random rare or mythic rare
+1 Placid Rottentail
+1 Fairgrounds Trumpeter
+1 Wary Thespian
+1 Converter Beast
+1 Timberland Ancient
+1 Arachnoid Adaptation
+1 Blighted Burgeoning
+1 Ruins Recluse
+1 Kami of Whispered Hopes
+1 Tandem Takedown
+1 Surrak and Goreclaw
+8 Forest

--- a/library/March of the Machine Jumpstart/Expendable-1.txt
+++ b/library/March of the Machine Jumpstart/Expendable-1.txt
@@ -1,0 +1,14 @@
+1 Random rare or mythic rare
+1 Injector Crocodile
+1 Dreg Recycler
+1 Etched Familiar
+1 Ichor Shade
+1 Final Flourish
+1 Unseal the Necropolis
+1 Deadly Derision
+1 Scorn-Blade Berserker
+1 Seer of Stolen Sight
+1 Gift of Compleation
+1 Terror of Towashi
+8 Swamp
+

--- a/library/March of the Machine Jumpstart/Expendable-2.txt
+++ b/library/March of the Machine Jumpstart/Expendable-2.txt
@@ -1,0 +1,14 @@
+1 Random rare or mythic rare
+1 Injector Crocodile
+1 Dreg Recycler
+1 Etched Familiar
+1 Corrupted Conviction
+1 Deadly Derision
+1 Failed Conversion
+1 Scorn-Blade Berserker
+1 Seer of Stolen Sight
+1 Gift of Compleation
+1 Compleated Huntmaster
+1 Terror of Towashi
+8 Swamp
+

--- a/library/March of the Machine Jumpstart/Overachiever-1.txt
+++ b/library/March of the Machine Jumpstart/Overachiever-1.txt
@@ -1,0 +1,14 @@
+1 Random rare or mythic rare
+1 Zephyr Winder
+1 Expedition Lookout
+1 Preening Champion
+1 Thunderhead Squadron
+1 Tidal Terror
+1 Ephara's Dispersal
+1 Meeting of Minds
+1 Temporal Cleansing
+1 Referee Squad
+1 Oracle of Tragedy
+1 Interdisciplinary Mascot
+8 Island
+

--- a/library/March of the Machine Jumpstart/Overachiever-2.txt
+++ b/library/March of the Machine Jumpstart/Overachiever-2.txt
@@ -1,0 +1,14 @@
+1 Random rare or mythic rare
+1 Zephyr Winder
+1 Referee Squad
+1 Interdisciplinary Mascot
+1 Tidal Terror
+1 Ephara's Dispersal
+1 Expedition Lookout
+1 Oracle of Tragedy
+1 Xerex Strobe-Knight
+1 Wicked Slumber
+1 Astral Wingspan
+1 Thunderhead Squadron
+8 Island
+

--- a/library/March of the Machine Jumpstart/Reinforcement-1.txt
+++ b/library/March of the Machine Jumpstart/Reinforcement-1.txt
@@ -1,0 +1,14 @@
+1 Random rare or mythic rare
+1 Cragsmasher Yeti
+1 Ral's Reinforcements
+1 Karsus Depthguard
+1 Hangar Scrounger
+1 Redcap Heelslasher
+1 Coming In Hot
+1 Volcanic Spite
+1 Axgard Artisan
+1 Fearless Skald
+1 Stoke the Flames
+1 Orthion, Hero of Lavabrink
+8 Mountain
+

--- a/library/March of the Machine Jumpstart/Reinforcement-2.txt
+++ b/library/March of the Machine Jumpstart/Reinforcement-2.txt
@@ -1,0 +1,14 @@
+1 Random rare or mythic rare
+1 Cragsmasher Yeti
+1 Trailblazing Historian
+1 Karsus Depthguard
+1 Hangar Scrounger
+1 Redcap Heelslasher
+1 Mirran Banesplitter
+1 Volcanic Spite
+1 Shatter the Source
+1 Axgard Artisan
+1 Fearless Skald
+1 Orthion, Hero of Lavabrink
+8 Mountain
+

--- a/library/Phyrexia: All Will Be One Jumpstart/Corruption-1.txt
+++ b/library/Phyrexia: All Will Be One Jumpstart/Corruption-1.txt
@@ -1,0 +1,15 @@
+1 Kinzu of the Bleak Coven
+1 Random rare or mythic rare
+1 Bonepicker Skirge
+1 Pestilent Syphoner
+1 Testament Bearer
+1 Annihilating Glare
+1 Anoint with Affliction
+1 Ambulatory Edifice
+1 Nimraiser Paladin
+1 Drown in Ichor
+1 Feed the Infection
+1 Dross Skullbomb
+1 The Dross Pits
+7 Swamp
+

--- a/library/Phyrexia: All Will Be One Jumpstart/Corruption-2.txt
+++ b/library/Phyrexia: All Will Be One Jumpstart/Corruption-2.txt
@@ -1,0 +1,15 @@
+1 Kinzu of the Bleak Coven
+1 Random rare or mythic rare
+1 Bonepicker Skirge
+1 Stinging Hivemaster
+1 Testament Bearer
+1 Offer Immortality
+1 Infectious Inquiry
+1 Vraska's Fall
+1 Bilious Skulldweller
+1 Chittering Skitterling
+1 Nimraiser Paladin
+1 Necrogen Communion
+1 The Dross Pits
+7 Swamp
+

--- a/library/Phyrexia: All Will Be One Jumpstart/Mite-y-1.txt
+++ b/library/Phyrexia: All Will Be One Jumpstart/Mite-y-1.txt
@@ -1,0 +1,15 @@
+1 Mite Overseer
+1 Random rare or mythic rare
+1 Bladed Ambassador
+1 Sinew Dancer
+1 Duelist of Deep Faith
+1 Basilica Shepherd
+1 Planar Disruption
+1 Charge of the Mites
+1 Vanish into Eternity
+1 Annex Sentry
+1 Porcelain Zealot
+1 Infested Fleshcutter
+1 The Fair Basilica
+7 Plains
+

--- a/library/Phyrexia: All Will Be One Jumpstart/Mite-y-2.txt
+++ b/library/Phyrexia: All Will Be One Jumpstart/Mite-y-2.txt
@@ -1,0 +1,15 @@
+7 Plains
+1 Mite Overseer
+1 Random rare or mythic rare
+1 Bladed Ambassador
+1 Crawling Chorus
+1 Mandible Justiciar
+1 Duelist of Deep Faith
+1 Zealot's Conviction
+1 Compleat Devotion
+1 Vanish into Eternity
+1 Porcelain Zealot
+1 Apostle of Invasion
+1 Ossification
+1 The Fair Basilica
+

--- a/library/Phyrexia: All Will Be One Jumpstart/Progress-1.txt
+++ b/library/Phyrexia: All Will Be One Jumpstart/Progress-1.txt
@@ -1,0 +1,15 @@
+1 Serum Sovereign
+1 Random rare or mythic rare
+1 Thrummingbird
+1 Glistener Seer
+1 Ichor Synthesizer
+1 Chrome Prowler
+1 Meldweb Curator
+1 Quicksilver Fisher
+1 Mesmerizing Dose
+1 Serum Snare
+1 Tamiyo's Immobilizer
+1 Distorted Curiosity
+1 The Surgical Bay
+7 Island
+

--- a/library/Phyrexia: All Will Be One Jumpstart/Progress-2.txt
+++ b/library/Phyrexia: All Will Be One Jumpstart/Progress-2.txt
@@ -1,0 +1,15 @@
+1 Serum Sovereign
+1 Random rare or mythic rare
+1 Thrummingbird
+1 Chrome Prowler
+1 Experimental Augury
+1 Bring the Ending
+1 Mesmerizing Dose
+1 Atmosphere Surgeon
+1 Trawler Drake
+1 Distorted Curiosity
+1 Myr Custodian
+1 Surgical Skullbomb
+1 The Surgical Bay
+7 Island
+

--- a/library/Phyrexia: All Will Be One Jumpstart/Rebellious-1.txt
+++ b/library/Phyrexia: All Will Be One Jumpstart/Rebellious-1.txt
@@ -1,0 +1,15 @@
+1 Rhuk, Hexgold Nabber
+1 Random rare or mythic rare
+1 Furnace Punisher
+1 Barbed Batterfist
+1 Vulshok Splitter
+1 Chimney Rabble
+1 Furnace Strider
+1 Free from Flesh
+1 Volt Charge
+1 Hexgold Halberd
+1 Resistance Skywarden
+1 Rebel Salvo
+1 The Autonomous Furnace
+7 Mountain
+

--- a/library/Phyrexia: All Will Be One Jumpstart/Rebellious-2.txt
+++ b/library/Phyrexia: All Will Be One Jumpstart/Rebellious-2.txt
@@ -1,0 +1,15 @@
+1 Rhuk, Hexgold Nabber
+1 Random rare or mythic rare
+1 Furnace Punisher
+1 Barbed Batterfist
+1 Bladegraft Aspirant
+1 Vulshok Splitter
+1 Hexgold Slash
+1 Blazing Crescendo
+1 Molten Rebuke
+1 Hexgold Halberd
+1 Oxidda Finisher
+1 Prosthetic Injector
+1 The Autonomous Furnace
+7 Mountain
+

--- a/library/Phyrexia: All Will Be One Jumpstart/Toxic-1.txt
+++ b/library/Phyrexia: All Will Be One Jumpstart/Toxic-1.txt
@@ -1,0 +1,15 @@
+1 Goliath Hatchery
+1 Random rare or mythic rare
+1 Cankerbloom
+1 Copper Longlegs
+1 Branchblight Stalker
+1 Contagious Vorrac
+1 Titanic Growth
+1 Venomous Brutalizer
+1 Paladin of Predation
+1 Infectious Bite
+1 Phyrexian Atlas
+1 Ichorspit Basilisk
+1 The Hunter Maze
+7 Forest
+

--- a/library/Phyrexia: All Will Be One Jumpstart/Toxic-2.txt
+++ b/library/Phyrexia: All Will Be One Jumpstart/Toxic-2.txt
@@ -1,0 +1,15 @@
+1 Goliath Hatchery
+1 Cankerbloom (ichor treatment)&nbsp;
+1 Random green rare or mythic rare&nbsp;
+1 Rustvine Cultivator
+1 Branchblight Stalker
+1 Contagious Vorrac
+1 Ruthless Predation
+1 Viral Spawning
+1 Paladin of Predation
+1 Tyvar's Stand
+1 Lattice-Blade Mantis
+1 Maze's Mantle
+1 The Hunter Maze
+7 Forest
+

--- a/library/The Brothers' War Jumpstart/Infantry-1.txt
+++ b/library/The Brothers' War Jumpstart/Infantry-1.txt
@@ -1,0 +1,14 @@
+1 Rescue Retriever
+1 Random white rare or mythic rare
+1 Aeronaut Cavalry
+1 Airlift Chaplain
+1 Lay Down Arms
+1 Phalanx Vanguard
+1 Recommission
+1 Recruitment Officer
+1 Static Net
+1 Warlord's Elite
+1 Veteran's Powerblade
+1 Reconstructed Thopter
+6 Plains
+2 Plains [Foil]

--- a/library/The Brothers' War Jumpstart/Infantry-2.txt
+++ b/library/The Brothers' War Jumpstart/Infantry-2.txt
@@ -1,0 +1,14 @@
+1 Rescue Retriever
+1 Random white rare or mythic rare
+1 Aeronaut Cavalry
+1 Ambush Paratrooper
+1 Lay Down Arms
+1 Phalanx Vanguard
+1 Static Net
+1 Thopter Architect
+1 Warlord's Elite
+1 Scrapwork Cohort
+1 Veteran's Powerblade
+1 Yotian Frontliner
+6 Plains
+2 Plains [Foi]

--- a/library/The Brothers' War Jumpstart/Powerstones-1.txt
+++ b/library/The Brothers' War Jumpstart/Powerstones-1.txt
@@ -1,0 +1,14 @@
+1 Geology Enthusiast
+1 Random blue rare or mythic rare; or Liberator, Urza's Battlethopter; or Thran Spider
+1 Koilos Roc
+1 Stern Lesson
+1 Take Flight
+1 Third Path Savant
+1 Thopter Mechanic
+1 Urza, Powerstone Prodigy
+1 Urza's Rebuff
+1 Weakstone's Subjugation
+1 Combat Courier
+1 Spotter Thopter
+6 Island
+2 Island [Foil]

--- a/library/The Brothers' War Jumpstart/Powerstones-2.txt
+++ b/library/The Brothers' War Jumpstart/Powerstones-2.txt
@@ -1,0 +1,14 @@
+1 Geology Enthusiast
+1 Random blue rare or mythic rare; or Liberator, Urza's Battlethopter; or Thran Spider
+1 Involuntary Cooldown
+1 Koilos Roc
+1 Lat-Nam Adept
+1 Mightstone's Animation
+1 Stern Lesson
+1 Thopter Mechanic
+1 Urza, Powerstone Prodigy
+1 Weakstone's Subjugation
+1 Combat Courier
+1 Hulking Metamorph
+6 Island
+2 Island [Foil]

--- a/library/The Brothers' War Jumpstart/Titanic-1.txt
+++ b/library/The Brothers' War Jumpstart/Titanic-1.txt
@@ -1,0 +1,14 @@
+1 Woodcaller Automaton
+1 Random green rare or mythic rare
+1 Argothian Opportunist
+1 Blanchwood Prowler
+1 Bushwhack
+1 Gaea's Gift
+1 Giant Growth
+1 Sarinth Steelseeker
+1 Shoot Down
+1 Cradle Clearcutter
+1 Iron-Craw Crusher
+1 Rust Goliath
+6 Forest
+2 Forest [Foil]

--- a/library/The Brothers' War Jumpstart/Titanic-2.txt
+++ b/library/The Brothers' War Jumpstart/Titanic-2.txt
@@ -1,0 +1,14 @@
+1 Woodcaller Automaton
+1 Random green rare or mythic rare
+1 Argothian Sprite
+1 Bushwhack
+1 Epic Confrontation
+1 Perimeter Patrol
+1 Sarinth Steelseeker
+1 Shoot Down
+1 Tawnos's Tinkering
+1 Cradle Clearcutter
+1 Iron-Craw Crusher
+1 Rust Goliath
+6 Forest
+2 Forest [Foil]

--- a/library/The Brothers' War Jumpstart/Unearthed-1.txt
+++ b/library/The Brothers' War Jumpstart/Unearthed-1.txt
@@ -1,0 +1,14 @@
+1 Terror Ballista
+1 Random black rare or mythic rare
+1 Ashnod's Intervention
+1 Go for the Throat
+1 Gruesome Realization
+1 Kill-Zone Acrobat
+1 No One Left Behind
+1 Ravenous Gigamole
+1 Thraxodemon
+1 Ashnod's Harvester
+1 Clay Revenant
+1 Scrapwork Rager
+6 Swamp
+2 Swamp [Foil]

--- a/library/The Brothers' War Jumpstart/Unearthed-2.txt
+++ b/library/The Brothers' War Jumpstart/Unearthed-2.txt
@@ -1,0 +1,14 @@
+1 Terror Ballista
+1 Random black rare or mythic rare
+1 Gixian Skullflayer
+1 Gnawing Vermin
+1 Gruesome Realization
+1 Overwhelming Remorse
+1 Ravenous Gigamole
+1 Thraxodemon
+1 Ashnod's Harvester
+1 Dredging Claw
+1 Scrapwork Rager
+1 Transmogrant Altar
+6 Swamp
+2 Swamp [Foil]

--- a/library/The Brothers' War Jumpstart/Welded-1.txt
+++ b/library/The Brothers' War Jumpstart/Welded-1.txt
@@ -1,0 +1,14 @@
+1 Artificer's Dragon
+1 Random red rare or mythic rare
+1 Bitter Reunion
+1 Fallaji Chaindancer
+1 Horned Stoneseeker
+1 Mishra, Excavation Prodigy
+1 Obliterating Bolt
+1 Unleash Shell
+1 Whirling Strike
+1 Fallaji Dragon Engine
+1 Mishra's Juggernaut
+1 Scrapwork Mutt
+6 Mountain
+2 Mountain [Foil]

--- a/library/The Brothers' War Jumpstart/Welded-2.txt
+++ b/library/The Brothers' War Jumpstart/Welded-2.txt
@@ -1,0 +1,14 @@
+1 Artificer's Dragon
+1 Random red rare or mythic rare
+1 Excavation Explosion
+1 Horned Stoneseeker
+1 Mishra, Excavation Prodigy
+1 Mishra's Onslaught
+1 Tomakul Scrapsmith
+1 Unleash Shell
+1 Fallaji Dragon Engine
+1 Mishra's Juggernaut
+1 Mishra's Research Desk
+1 Scrapwork Mutt
+6 Mountain
+2 Mountain [Foil]

--- a/main.py
+++ b/main.py
@@ -4,24 +4,56 @@ import time
 import requests
 import json
 import re
+import logging
 from fpdf import FPDF
 
-# Constants
+# Logging configuration
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(),
+        logging.FileHandler('card_generator.log')
+    ]
+)
+logger = logging.getLogger(__name__)
+
+# API Configuration
 SCRYFALL_API_URL = "https://api.scryfall.com/cards/named"
 SCRYFALL_SYMBOLOGY_URL = "https://api.scryfall.com/symbology"
+API_RATE_LIMIT_DELAY = 0.1  # seconds between API calls
+
+# File and Directory Configuration
 CACHE_FILE = "card_cache.json"
 SYMBOLS_CACHE_FILE = "symbols_cache.json"
 SYMBOLS_DIR = "cache/symbols"
+INPUT_DIR = "files"
+
+# PDF Layout Constants
 CARD_WIDTH_MM = 62
 CARD_HEIGHT_MM = 87
 MARGIN_MM = 10
 SPACING_MM = 2
 CARDS_PER_ROW = 3
 CARDS_PER_COL = 3
+
+# Typography Constants
 FONT_SIZE_TITLE = 10
 FONT_SIZE_ITEM = 8
 LINE_HEIGHT = 4
-SYMBOL_SIZE = 3 # mm
+
+# Symbol Rendering Constants
+SYMBOL_SIZE = 3  # mm
+SYMBOL_PADDING_BASE = 0.5
+
+# Card Layout Constants
+TITLE_HEIGHT_MM = 6
+TITLE_PADDING_MM = 2
+TITLE_Y_OFFSET_MM = 2
+TITLE_X_OFFSET_MM = 2
+ITEM_START_Y_OFFSET_MM = 10
+ITEM_X_OFFSET_MM = 2
+AVAILABLE_HEIGHT_BUFFER_MM = 12
 
 def ensure_dirs():
     if not os.path.exists(SYMBOLS_DIR):
@@ -43,42 +75,68 @@ def get_symbology_map():
     """
     cache = load_json(SYMBOLS_CACHE_FILE)
     if cache:
+        logger.debug(f"Loaded {len(cache)} symbols from cache")
         return cache
 
-    print("Fetching symbology from Scryfall...")
+    logger.info("Fetching symbology from Scryfall...")
     try:
-        response = requests.get(SCRYFALL_SYMBOLOGY_URL)
-        if response.status_code == 200:
-            data = response.json()
-            mapping = {item["symbol"]: item["svg_uri"] for item in data["data"]}
-            save_json(SYMBOLS_CACHE_FILE, mapping)
-            return mapping
-    except Exception as e:
-        print(f"Error fetching symbology: {e}")
-    
-    return {}
+        response = requests.get(SCRYFALL_SYMBOLOGY_URL, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        mapping = {item["symbol"]: item["svg_uri"] for item in data["data"]}
+        save_json(SYMBOLS_CACHE_FILE, mapping)
+        logger.info(f"Successfully fetched {len(mapping)} symbols")
+        return mapping
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Failed to fetch symbology from Scryfall: {e}")
+        raise
+    except (KeyError, ValueError) as e:
+        logger.error(f"Failed to parse symbology response: {e}")
+        raise
 
 def get_symbol_image_path(symbol, uri):
     """
     Downloads the symbol SVG if not present. Returns path to local file.
+    Safely sanitizes the symbol name to prevent path traversal attacks.
     """
-    safe_name = symbol.replace("{", "").replace("}", "").replace("/", "")
+    # Properly sanitize filename - remove all special characters and path separators
+    safe_name = re.sub(r'[^a-zA-Z0-9_-]', '', symbol.replace("{", "").replace("}", ""))
+    if not safe_name:
+        logger.error(f"Invalid symbol name after sanitization: {symbol}")
+        return None
+
+    # Use basename as an extra security measure
+    safe_name = os.path.basename(safe_name)
     filename = os.path.join(SYMBOLS_DIR, f"{safe_name}.svg")
-    
+
+    # Ensure the path is still within SYMBOLS_DIR (prevent directory traversal)
+    if not os.path.abspath(filename).startswith(os.path.abspath(SYMBOLS_DIR)):
+        logger.error(f"Path traversal attempt detected for symbol: {symbol}")
+        return None
+
     if os.path.exists(filename):
         return filename
-        
-    print(f"Downloading symbol {symbol}...")
+
+    logger.info(f"Downloading symbol {symbol}...")
     try:
-        response = requests.get(uri)
-        if response.status_code == 200:
-            with open(filename, "wb") as f:
-                f.write(response.content)
-            return filename
-    except Exception as e:
-        print(f"Error downloading symbol {symbol}: {e}")
-    
-    return None
+        response = requests.get(uri, timeout=10)
+        response.raise_for_status()
+
+        # Validate content type
+        content_type = response.headers.get('content-type', '')
+        if 'svg' not in content_type.lower() and 'xml' not in content_type.lower():
+            logger.warning(f"Unexpected content type for symbol {symbol}: {content_type}")
+
+        with open(filename, "wb") as f:
+            f.write(response.content)
+        logger.debug(f"Successfully downloaded symbol {symbol} to {filename}")
+        return filename
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Failed to download symbol {symbol} from {uri}: {e}")
+        return None
+    except IOError as e:
+        logger.error(f"Failed to write symbol {symbol} to disk: {e}")
+        return None
 
 def get_card_data(card_name, cache):
     """
@@ -86,53 +144,72 @@ def get_card_data(card_name, cache):
     Returns a dict with 'name', 'mana_cost', and 'type_line'.
     """
     key = card_name.lower().strip()
-    if key in cache:
-        # Backward compatibility for cache without type_line
-        if 'type_line' not in cache[key]:
-             pass # Force re-fetch
-        else:
-            return cache[key]
 
-    print(f"Fetching data for {card_name}...")
+    # Check cache and validate it has all required fields
+    if key in cache:
+        cached_data = cache[key]
+        # Backward compatibility: re-fetch if cache is missing type_line
+        if 'type_line' in cached_data and 'mana_cost' in cached_data and 'name' in cached_data:
+            logger.debug(f"Using cached data for '{card_name}'")
+            return cached_data
+        else:
+            logger.info(f"Cache entry for '{card_name}' is incomplete, re-fetching")
+
+    logger.info(f"Fetching data for '{card_name}' from Scryfall...")
     try:
-        time.sleep(0.1) 
-        response = requests.get(SCRYFALL_API_URL, params={"exact": card_name})
-        
+        # Rate limiting
+        time.sleep(API_RATE_LIMIT_DELAY)
+
+        # Try exact match first
+        response = requests.get(SCRYFALL_API_URL, params={"exact": card_name}, timeout=10)
+
+        # Fall back to fuzzy search if exact match fails
         if response.status_code == 404:
-            response = requests.get(SCRYFALL_API_URL, params={"fuzzy": card_name})
-        
+            logger.debug(f"Exact match failed for '{card_name}', trying fuzzy search")
+            response = requests.get(SCRYFALL_API_URL, params={"fuzzy": card_name}, timeout=10)
+
         if response.status_code != 200:
             # Check for Basic Land variants (e.g., "Plains Appa")
             basic_lands = ["Plains", "Island", "Swamp", "Mountain", "Forest", "Wastes"]
             for land in basic_lands:
                 if card_name.startswith(land):
-                    print(f"Assuming '{card_name}' is a variant of {land}")
-                    return {"name": card_name, "mana_cost": "", "type_line": f"Basic Land — {land}"}
+                    logger.info(f"Assuming '{card_name}' is a variant of {land}")
+                    result = {"name": card_name, "mana_cost": "", "type_line": f"Basic Land — {land}"}
+                    cache[key] = result
+                    return result
 
-            print(f"Error: Could not find card '{card_name}'")
+            logger.error(f"Could not find card '{card_name}' (status: {response.status_code})")
             return {"name": card_name, "mana_cost": "???", "type_line": "Unknown"}
 
         data = response.json()
-        
+
+        # Extract mana cost
         mana_cost = ""
-        type_line = ""
-        
         if "mana_cost" in data:
             mana_cost = data["mana_cost"]
-        elif "card_faces" in data and "mana_cost" in data["card_faces"][0]:
+        elif "card_faces" in data and len(data["card_faces"]) > 0 and "mana_cost" in data["card_faces"][0]:
             mana_cost = data["card_faces"][0]["mana_cost"]
-            
+
+        # Extract type line
+        type_line = ""
         if "type_line" in data:
             type_line = data["type_line"]
-        elif "card_faces" in data and "type_line" in data["card_faces"][0]:
+        elif "card_faces" in data and len(data["card_faces"]) > 0 and "type_line" in data["card_faces"][0]:
             type_line = data["card_faces"][0]["type_line"]
-            
+
         result = {"name": data.get("name", card_name), "mana_cost": mana_cost, "type_line": type_line}
         cache[key] = result
+        logger.debug(f"Successfully fetched data for '{card_name}'")
         return result
 
-    except Exception as e:
-        print(f"Exception fetching '{card_name}': {e}")
+    except requests.exceptions.Timeout:
+        logger.error(f"Timeout while fetching '{card_name}'")
+        return {"name": card_name, "mana_cost": "Error", "type_line": "Error"}
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Request failed for '{card_name}': {e}")
+        return {"name": card_name, "mana_cost": "Error", "type_line": "Error"}
+    except (KeyError, ValueError, json.JSONDecodeError) as e:
+        logger.error(f"Failed to parse response for '{card_name}': {e}")
         return {"name": card_name, "mana_cost": "Error", "type_line": "Error"}
 
 def get_card_group(type_line):
@@ -203,72 +280,71 @@ def create_pdf(card_lists, list_names, output_filename="checklist_cards.pdf"):
         
         # 4. Calculate Layout & Scaling
         # Available height for items = Card Height - Title Height - Padding
-        # Title takes ~6mm + 2mm padding = 8mm. Let's say 10mm to be safe.
-        available_height = CARD_HEIGHT_MM - 12 
+        available_height = CARD_HEIGHT_MM - AVAILABLE_HEIGHT_BUFFER_MM
         total_items = len(display_items)
-        
+
         current_line_height = LINE_HEIGHT
         current_font_size = FONT_SIZE_ITEM
         current_symbol_size = SYMBOL_SIZE
-        
+
         required_height = total_items * LINE_HEIGHT
-        
+
         if required_height > available_height and total_items > 0:
             scale_factor = available_height / required_height
             current_line_height = LINE_HEIGHT * scale_factor
             current_font_size = FONT_SIZE_ITEM * scale_factor
             current_symbol_size = SYMBOL_SIZE * scale_factor
-            # Optional: Set a minimum font size limit if needed, but user asked to fit it.
-        
+            logger.debug(f"Scaling card '{list_name}' by factor {scale_factor:.2f} to fit {total_items} items")
+
         # 5. Draw Card
         x = x_start_base + (col * (CARD_WIDTH_MM + SPACING_MM))
         y = y_start_base + (row * (CARD_HEIGHT_MM + SPACING_MM))
-        
+
         # Draw Card Border
         pdf.rect(x, y, CARD_WIDTH_MM, CARD_HEIGHT_MM)
-        
+
         # Draw Title
-        pdf.set_xy(x + 2, y + 2)
+        pdf.set_xy(x + TITLE_X_OFFSET_MM, y + TITLE_Y_OFFSET_MM)
         pdf.set_font("Arial", 'B', FONT_SIZE_TITLE)
-        pdf.cell(CARD_WIDTH_MM - 4, 6, list_name, align='C', ln=1)
-        
+        pdf.cell(CARD_WIDTH_MM - 4, TITLE_HEIGHT_MM, list_name, align='C', ln=1)
+
         # Draw Items
-        current_y = y + 10 # Start below title
+        current_y = y + ITEM_START_Y_OFFSET_MM  # Start below title
         
         for item in display_items:
-            pdf.set_xy(x + 2, current_y)
-            
+            pdf.set_xy(x + ITEM_X_OFFSET_MM, current_y)
+
             if item.get('type') == 'header':
                 pdf.set_font("Arial", 'B', current_font_size)
                 pdf.cell(CARD_WIDTH_MM - 4, current_line_height, f"{item['name']}:", ln=1)
                 current_y += current_line_height
                 continue
-            
+
             # It's a card
             pdf.set_font("Arial", '', current_font_size)
-            
+
             # Prepare Mana Symbols
             mana_cost = item['mana_cost']
             symbols = []
             if mana_cost:
                 symbols = re.findall(r'\{.*?\}', mana_cost)
-            
+
             # Calculate width needed for symbols
-            symbol_padding = 0.5 * (current_symbol_size / SYMBOL_SIZE) # Scale padding too
+            symbol_padding = SYMBOL_PADDING_BASE * (current_symbol_size / SYMBOL_SIZE)  # Scale padding too
             total_symbol_width = 0
             valid_symbols = []
-            
+
             for sym in symbols:
                 if sym in symbology:
-                        total_symbol_width += current_symbol_size + symbol_padding
-                        valid_symbols.append({'type': 'img', 'val': sym})
+                    total_symbol_width += current_symbol_size + symbol_padding
+                    valid_symbols.append({'type': 'img', 'val': sym})
                 else:
-                        w = pdf.get_string_width(sym)
-                        total_symbol_width += w + symbol_padding
-                        valid_symbols.append({'type': 'text', 'val': sym})
+                    w = pdf.get_string_width(sym)
+                    total_symbol_width += w + symbol_padding
+                    valid_symbols.append({'type': 'text', 'val': sym})
 
             # Draw Symbols Right-Aligned
-            draw_x = x + CARD_WIDTH_MM - 2 - total_symbol_width
+            draw_x = x + CARD_WIDTH_MM - ITEM_X_OFFSET_MM - total_symbol_width
             
             for sym_data in valid_symbols:
                 if sym_data['type'] == 'img':
@@ -286,80 +362,88 @@ def create_pdf(card_lists, list_names, output_filename="checklist_cards.pdf"):
             qty = item['quantity']
             name = item['name']
             text_str = f"{qty}x {name}"
-            
-            max_text_width = CARD_WIDTH_MM - 4 - total_symbol_width - 1
-            
+
+            max_text_width = CARD_WIDTH_MM - (2 * ITEM_X_OFFSET_MM) - total_symbol_width - 1
+
             if pdf.get_string_width(text_str) > max_text_width:
                 while pdf.get_string_width(text_str + "...") > max_text_width and len(text_str) > 0:
                     text_str = text_str[:-1]
                 text_str += "..."
-            
-            pdf.set_xy(x + 2, current_y)
+
+            pdf.set_xy(x + ITEM_X_OFFSET_MM, current_y)
             pdf.cell(max_text_width, current_line_height, text_str)
-                        
+
             current_y += current_line_height
-        
+
         col += 1
         if col >= CARDS_PER_ROW:
             col = 0
             row += 1
-            
+
         if row >= CARDS_PER_COL:
             pdf.add_page()
             col = 0
             row = 0
-    
+
     save_json(CACHE_FILE, cache)
     pdf.output(output_filename)
-    print(f"PDF generated: {output_filename}")
+    logger.info(f"PDF generated successfully: {output_filename}")
 
 def main():
-    input_dir = "files"
-    if not os.path.exists(input_dir):
-        os.makedirs(input_dir)
-        print(f"Created '{input_dir}' directory. Please put your .txt files there and run again.")
+    """Main entry point for the card checklist generator."""
+    if not os.path.exists(INPUT_DIR):
+        os.makedirs(INPUT_DIR)
+        logger.warning(f"Created '{INPUT_DIR}' directory. Please put your .txt files there and run again.")
         return
 
-    input_files = [os.path.join(input_dir, f) for f in os.listdir(input_dir) if f.endswith(".txt")]
-    
+    input_files = [os.path.join(INPUT_DIR, f) for f in os.listdir(INPUT_DIR) if f.endswith(".txt")]
+
     if not input_files:
-        print(f"No .txt files found in '{input_dir}' directory.")
+        logger.warning(f"No .txt files found in '{INPUT_DIR}' directory.")
         return
 
     all_lists = []
     list_names = []
-    
-    print(f"Found {len(input_files)} files in '{input_dir}':")
+
+    logger.info(f"Found {len(input_files)} files in '{INPUT_DIR}':")
     for file_path in input_files:
-        print(f" - {os.path.basename(file_path)}")
-        
-        with open(file_path, "r", encoding="utf-8") as f:
-            parsed_list = []
-            for line in f:
-                line = line.strip()
-                if not line: continue
-                
-                # Remove bracketed content like [12345]
-                line = re.sub(r'\[.*?\]', '', line).strip()
-                
-                # Parse quantity: "3x Mountain" or "7 Island" or "Mountain"
-                match = re.match(r'^(\d+)(?:x)?\s+(.*)$', line)
-                if match:
-                    qty = int(match.group(1))
-                    name = match.group(2).strip()
-                else:
-                    qty = 1
-                    name = line
-                
-                parsed_list.append((qty, name))
-            
-            all_lists.append(parsed_list)
-            list_names.append(os.path.basename(file_path).replace(".txt", ""))
+        logger.info(f" - {os.path.basename(file_path)}")
+
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                parsed_list = []
+                for line_num, line in enumerate(f, 1):
+                    line = line.strip()
+                    if not line:
+                        continue
+
+                    # Remove bracketed content like [12345]
+                    line = re.sub(r'\[.*?\]', '', line).strip()
+
+                    # Parse quantity: "3x Mountain" or "7 Island" or "Mountain"
+                    match = re.match(r'^(\d+)(?:x)?\s+(.*)$', line)
+                    if match:
+                        qty = int(match.group(1))
+                        name = match.group(2).strip()
+                    else:
+                        qty = 1
+                        name = line
+
+                    if name:  # Only add if name is not empty
+                        parsed_list.append((qty, name))
+
+                all_lists.append(parsed_list)
+                list_names.append(os.path.basename(file_path).replace(".txt", ""))
+                logger.debug(f"Parsed {len(parsed_list)} cards from {os.path.basename(file_path)}")
+
+        except IOError as e:
+            logger.error(f"Failed to read file {file_path}: {e}")
+            continue
 
     if all_lists:
         create_pdf(all_lists, list_names)
     else:
-        print("No valid lists found.")
+        logger.warning("No valid lists found.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR adds a library of additional Jumpstart cards from the WotC site that I was able to extract. This should help make it easier for anyone trying to make these for their own sets, so they don't have to compile the lists manually.
